### PR TITLE
Tests for Array Types and Type Aliases

### DIFF
--- a/test/programs/array-types/main.ts
+++ b/test/programs/array-types/main.ts
@@ -1,0 +1,3 @@
+interface MyArray {
+    [index: number]: string | number;
+}

--- a/test/programs/array-types/schema.json
+++ b/test/programs/array-types/schema.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "array",
+    "items": {
+        "anyOf": [
+            {"type": "string"},
+            {"type": "number"}
+        ]
+    }
+}

--- a/test/programs/type-aliases-fixed-size-array/main.ts
+++ b/test/programs/type-aliases-fixed-size-array/main.ts
@@ -1,0 +1,1 @@
+type MyFixedSizeArray = [string, number];

--- a/test/programs/type-aliases-fixed-size-array/schema.json
+++ b/test/programs/type-aliases-fixed-size-array/schema.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "array",
+    "items": [
+        {"type": "string"},
+        {"type": "number"}
+    ],
+    "minItems": 2,
+    "maxItems": 2
+}

--- a/test/programs/type-aliases/main.ts
+++ b/test/programs/type-aliases/main.ts
@@ -1,0 +1,1 @@
+type MyString = string;

--- a/test/programs/type-aliases/schema.json
+++ b/test/programs/type-aliases/schema.json
@@ -1,0 +1,4 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "string"
+}


### PR DESCRIPTION
For TypeScript compiler, type `[string, number]` accepts the following values:
```typescript
['a', 1]
['a', 1, 2]
['a', 1, 2, 'b']
```

But I wish such a type can represent a fixed size array, so I added test files under the folder `type-aliases-fixed-size-array`. What do you think about this idea?