### PR TITLE
Add test for bugged enum name generation

### DIFF
--- a/test/programs/type-aliases-union-namespace/main.ts
+++ b/test/programs/type-aliases-union-namespace/main.ts
@@ -1,0 +1,17 @@
+
+export namespace Cardinal {
+    export const NORTH: 'north' = 'north';
+    export type NORTH = typeof NORTH;
+    export const SOUTH: 'south' = 'south';
+    export type SOUTH = typeof SOUTH;
+    export const EAST: 'east' = 'east';
+    export type EAST = typeof EAST;
+    export const WEST: 'west' = 'west';
+    export type WEST = typeof WEST;
+}
+
+export type Cardinal = Cardinal.NORTH | Cardinal.SOUTH | Cardinal.EAST | Cardinal.WEST;
+
+export interface MyModel {
+    direction: Cardinal;
+}

--- a/test/programs/type-aliases-union-namespace/schema.json
+++ b/test/programs/type-aliases-union-namespace/schema.json
@@ -1,0 +1,18 @@
+{
+    "type": "object",
+    "properties": {
+        "direction": {
+            "enum": [
+                "north",
+                "south",
+                "east",
+                "west"
+            ],
+            "type": "string"
+        }
+    },
+    "required": [
+        "direction"
+    ],
+    "$schema": "http://json-schema.org/draft-04/schema#"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -68,6 +68,7 @@ describe("schema", function () {
     assertSchema("comments-override", "main.ts", "MyObject");
     
     assertSchema("type-union-tagged", "main.ts", "Shape");
+    assertSchema("type-aliases-union-namespace", "main.ts", "MyModel");
     
     assertSchema("strict-null-checks", "main.ts", "MyObject", undefined, {
         strictNullChecks: true


### PR DESCRIPTION
String literal unions using references to string literals nested within objects generate types with incorrect full names. This test exposes the bug. I expect line 555 of `typescript-json-schema.ts` will need to be adjusted to correctly handle this structure's type name.

@domoritz This exposes the issue I talked about [here](https://github.com/vega/vega-lite/pull/1649) - I don't have a fix yet. Do you have any insight?