### PR TITLE
WIP: Add type aliasing tests.

### DIFF
--- a/test/programs/type-aliases-alias-ref-topref/main.ts
+++ b/test/programs/type-aliases-alias-ref-topref/main.ts
@@ -1,0 +1,7 @@
+
+interface MyObject {
+    number: number;
+    string: string;
+}
+
+type MyAlias = MyObject;

--- a/test/programs/type-aliases-alias-ref-topref/schema.json
+++ b/test/programs/type-aliases-alias-ref-topref/schema.json
@@ -1,0 +1,21 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "definitions": {
+        "MyObject": {
+            "type": "object",
+            "properties": {
+                "number": {
+                    "type": "number"
+                },
+                "string": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "number",
+                "string"
+            ]
+        }
+    },
+    "$ref": "#/definitions/MyObject"
+}

--- a/test/programs/type-aliases-alias-ref/main.ts
+++ b/test/programs/type-aliases-alias-ref/main.ts
@@ -1,0 +1,7 @@
+
+interface MyObject {
+    number: number;
+    string: string;
+}
+
+type MyAlias = MyObject;

--- a/test/programs/type-aliases-alias-ref/schema.json
+++ b/test/programs/type-aliases-alias-ref/schema.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "number": {
+            "type": "number"
+        },
+        "string": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "number",
+        "string"
+    ],
+    "type": "object"
+}

--- a/test/programs/type-aliases-recursive-alias-topref/main.ts
+++ b/test/programs/type-aliases-recursive-alias-topref/main.ts
@@ -1,0 +1,7 @@
+
+interface MyObject {
+    alias: MyAlias;
+    self: MyObject;
+}
+
+type MyAlias = MyObject;

--- a/test/programs/type-aliases-recursive-alias-topref/schema.json
+++ b/test/programs/type-aliases-recursive-alias-topref/schema.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "definitions": {
+        "MyAlias": {
+            "properties": {
+                "alias": {
+                    "$ref": "#/definitions/MyAlias"
+                },
+                "self": {
+                    "$ref": "#/definitions/MyObject"
+                }
+            },
+            "required": [
+                "alias",
+                "self"
+            ],
+            "type": "object"
+        },
+        "MyObject": {
+            "properties": {
+                "alias": {
+                    "$ref": "#/definitions/MyAlias"
+                },
+                "self": {
+                    "$ref": "#/definitions/MyObject"
+                }
+            },
+            "required": [
+                "alias",
+                "self"
+            ],
+            "type": "object"
+        }
+    },
+    "$ref": "#/definitions/MyObject"
+}

--- a/test/programs/type-aliases-recursive-object-topref/main.ts
+++ b/test/programs/type-aliases-recursive-object-topref/main.ts
@@ -1,0 +1,7 @@
+
+interface MyObject {
+    alias: MyAlias;
+    self: MyObject;
+}
+
+type MyAlias = MyObject;

--- a/test/programs/type-aliases-recursive-object-topref/schema.json
+++ b/test/programs/type-aliases-recursive-object-topref/schema.json
@@ -1,0 +1,36 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "definitions": {
+        "MyAlias": {
+            "properties": {
+                "alias": {
+                    "$ref": "#/definitions/MyAlias"
+                },
+                "self": {
+                    "$ref": "#/definitions/MyObject"
+                }
+            },
+            "required": [
+                "alias",
+                "self"
+            ],
+            "type": "object"
+        },
+        "MyObject": {
+            "properties": {
+                "alias": {
+                    "$ref": "#/definitions/MyAlias"
+                },
+                "self": {
+                    "$ref": "#/definitions/MyObject"
+                }
+            },
+            "required": [
+                "alias",
+                "self"
+            ],
+            "type": "object"
+        }
+    },
+    "$ref": "#/definitions/MyObject"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -76,6 +76,23 @@ describe("schema", function () {
         useTypeAliasRef: true
     });
 
+    assertSchema("type-aliases-alias-ref", "main.ts", "MyAlias", {
+        useTypeAliasRef: true,
+        useRootRef: false
+    });
+    assertSchema("type-aliases-alias-ref-topref", "main.ts", "MyAlias", {
+        useTypeAliasRef: true,
+        useRootRef: true
+    });
+    assertSchema("type-aliases-recursive-object-topref", "main.ts", "MyObject", {
+        useTypeAliasRef: true,
+        useRootRef: true
+    });
+    assertSchema("type-aliases-recursive-alias-topref", "main.ts", "MyAlias", {
+        useTypeAliasRef: true,
+        useRootRef: true
+    });
+
     assertSchema("type-anonymous", "main.ts", "MyObject");
     assertSchema("type-primitives", "main.ts", "MyObject");
     assertSchema("type-nullable", "main.ts", "MyObject");


### PR DESCRIPTION
Hi. I added some tests for type aliasing. The generated schemes are valid but they contain duplicate definitions of aliased types instead of `$ref`.

For example, it would be better if the schema from the `type-aliases-recursive-alias-topref` test
```json
{
    "$schema": "http://json-schema.org/draft-04/schema#",
    "definitions": {
        "MyAlias": {
            "properties": {
                "alias": {
                    "$ref": "#/definitions/MyAlias"
                },
                "self": {
                    "$ref": "#/definitions/MyObject"
                }
            },
            "required": [
                "alias",
                "self"
            ],
            "type": "object"
        },
        "MyObject": {
            "properties": {
                "alias": {
                    "$ref": "#/definitions/MyAlias"
                },
                "self": {
                    "$ref": "#/definitions/MyObject"
                }
            },
            "required": [
                "alias",
                "self"
            ],
            "type": "object"
        }
    },
    "$ref": "#/definitions/MyObject"
}
```

transformed to
```json
{
    "$schema": "http://json-schema.org/draft-04/schema#",
    "definitions": {
        "MyAlias": {
            "$ref": "#/definitions/MyObject"
        },
        "MyObject": {
            "properties": {
                "alias": {
                    "$ref": "#/definitions/MyAlias"
                },
                "self": {
                    "$ref": "#/definitions/MyObject"
                }
            },
            "required": [
                "alias",
                "self"
            ],
            "type": "object"
        }
    },
    "$ref": "#/definitions/MyAlias"
}
```