### PR TITLE
add test case for not directly used annotated type aliases

### DIFF
--- a/test/programs/type-aliases-annotated-import/def.ts
+++ b/test/programs/type-aliases-annotated-import/def.ts
@@ -1,0 +1,5 @@
+/**
+ * My string
+ * @format pattern [a-z]
+ */
+export type MyString = string;

--- a/test/programs/type-aliases-annotated-import/main.ts
+++ b/test/programs/type-aliases-annotated-import/main.ts
@@ -1,0 +1,5 @@
+import {MyString} from './def';
+
+interface MyObject {
+    s: MyString
+}

--- a/test/programs/type-aliases-annotated-import/schema.json
+++ b/test/programs/type-aliases-annotated-import/schema.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "definitions": {
+        "MyString": {
+            "description": "My string",
+            "format": "pattern [a-z]",
+            "type": "string"
+        }
+    },
+    "properties": {
+        "s": {
+            "$ref": "#/definitions/MyString"
+        }
+    },
+    "required": [
+        "s"
+    ],
+    "type": "object"
+}

--- a/test/programs/type-aliases-annotated-unref/main.ts
+++ b/test/programs/type-aliases-annotated-unref/main.ts
@@ -1,0 +1,7 @@
+/**
+ * My string
+ *
+ * @format pattern [a-z]
+ */
+type MyString = string
+

--- a/test/programs/type-aliases-annotated-unref/schema.json
+++ b/test/programs/type-aliases-annotated-unref/schema.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "My string",
+    "format": "pattern [a-z]",
+    "type": "string"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -139,6 +139,10 @@ describe("schema", () => {
         useTypeAliasRef: false,
         useRootRef: true
     });
+    assertSchema("type-aliases-annotated-unref", "main.ts", "MyString");
+    assertSchema("type-aliases-annotated-import", "main.ts", "MyObject", {
+        useTypeAliasRef: true
+    });
 
     /**
      *  unions and intersections


### PR DESCRIPTION
see #92 
I also tried to fix it, but I fear it will cause quite some changes.
As I see it, `allSymbols` contains `Type`s. These are resolved types (string instead of MyString in the test case) and the annotation information is lost.
So `allSymbols` should probably contain `Symbol`s or `Node`s to preserve the unresolved types.