### PR TITLE
default annotation should accept any value

### DIFF
--- a/test/programs/annotation-default/main.ts
+++ b/test/programs/annotation-default/main.ts
@@ -1,0 +1,38 @@
+interface MyObject {
+  /**
+   * @default true
+   */
+  varBoolean: boolean;
+  /**
+   * @default 123
+   */
+  varInteger: number;
+  /**
+   * @default 3.21
+   */
+  varFloat: number;
+  /**
+   * @default "foo"
+   */
+  varString: string;
+  /**
+   * @default [true, false, true]
+   */
+  varBooleanArray: boolean[];
+  /**
+   * @default [1, 2, 3, 4, 5]
+   */
+  varIntegerArray: number[];
+  /**
+   * @default [1.23, 65.21, -123.40, 0, 1000000.0001]
+   */
+  varFloatArray: number[];
+  /**
+   * @default ["a", "b", "c", "..."]
+   */
+  varStringArray: string[];
+  /**
+   * @default [true, 123, 3.21, "foo"]
+   */
+  varMixedArray: any[];
+}

--- a/test/programs/annotation-default/schema.json
+++ b/test/programs/annotation-default/schema.json
@@ -1,0 +1,92 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "properties": {
+        "varBoolean": {
+            "default": true,
+            "type": "boolean"
+        },
+        "varBooleanArray": {
+            "default": [
+                true,
+                false,
+                true
+            ],
+            "items": {
+                "type": "boolean"
+            },
+            "type": "array"
+        },
+        "varFloat": {
+            "default": 3.21,
+            "type": "number"
+        },
+        "varFloatArray": {
+            "default": [
+                1.23,
+                65.21,
+                -123.4,
+                0,
+                1000000.0001
+            ],
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "varInteger": {
+            "default": 123,
+            "type": "number"
+        },
+        "varIntegerArray": {
+            "default": [
+                1,
+                2,
+                3,
+                4,
+                5
+            ],
+            "items": {
+                "type": "number"
+            },
+            "type": "array"
+        },
+        "varMixedArray": {
+            "default": [
+                true,
+                123,
+                3.21,
+                "foo"
+            ],
+            "items": {},
+            "type": "array"
+        },
+        "varString": {
+            "default": "foo",
+            "type": "string"
+        },
+        "varStringArray": {
+            "default": [
+                "a",
+                "b",
+                "c",
+                "..."
+            ],
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        }
+    },
+    "required": [
+        "varBoolean",
+        "varInteger",
+        "varFloat",
+        "varString",
+        "varBooleanArray",
+        "varIntegerArray",
+        "varFloatArray",
+        "varStringArray",
+        "varMixedArray"
+    ],
+    "type": "object"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -152,4 +152,10 @@ describe("schema", () => {
     assertSchema("strict-null-checks", "main.ts", "MyObject", undefined, {
         strictNullChecks: true
     });
+
+    /**
+     * annotations
+     */
+
+    assertSchema("annotation-default", "main.ts", "MyObject");
 });

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -114,14 +114,11 @@ export class JsonSchemaGenerator {
      * Try to parse a value and returns the string if it fails.
      */
     private parseValue(value: string) {
-        if (value === "false") {
-            return false;
+        try {
+            return JSON.parse(value);
+        } catch (error) {
+            return value;
         }
-        if (value === "true") {
-            return true;
-        }
-        let num = parseFloat(value);
-        return isNaN(num) ? value : num;
     }
 
     /**


### PR DESCRIPTION
This PR solves the problem mentioned on the issue #100.

There is a minor issue noted, for now it can't accept a object as a default value.

`@default {key: "value"}` fails

A quick workaround is to use quotes around the key name, so it will be treated like a valid JSON and correctly parsed as an object.

`@default {"key": "value"}` works

I think it can be improved later, but for now this PR adds a new feature without breaking the existing ones.
