### PR TITLE
Fixed types with same name in other files being overwritten

### DIFF
--- a/test/programs/imports/main.ts
+++ b/test/programs/imports/main.ts
@@ -1,0 +1,16 @@
+
+// This file imports "MyInterface" from the other 2 files
+// while also declaring a MyInterface type
+
+import { MyInterface as module1_MyInterface } from "./module1";
+import * as module2 from "./module2";
+
+class MyInterface {
+    fieldInMain: number;
+}
+
+class MyObject {
+    a: MyInterface;
+    b: module1_MyInterface;
+    c: module2.MyInterface;
+}

--- a/test/programs/imports/module1.ts
+++ b/test/programs/imports/module1.ts
@@ -1,0 +1,5 @@
+
+export class MyInterface {
+    fieldInModule1: string;
+}
+

--- a/test/programs/imports/module2.ts
+++ b/test/programs/imports/module2.ts
@@ -1,0 +1,5 @@
+
+export class MyInterface {
+    fieldInModule2: number;
+}
+

--- a/test/programs/imports/schema.json
+++ b/test/programs/imports/schema.json
@@ -1,0 +1,56 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "definitions": {
+        "MyInterface": {
+            "properties": {
+                "fieldInMain": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "fieldInMain"
+            ],
+            "type": "object"
+        },
+        "MyInterface_1": {
+            "properties": {
+                "fieldInModule1": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "fieldInModule1"
+            ],
+            "type": "object"
+        },
+        "MyInterface_2": {
+            "properties": {
+                "fieldInModule2": {
+                    "type": "number"
+                }
+            },
+            "required": [
+                "fieldInModule2"
+            ],
+            "type": "object"
+        }
+    },
+    "properties": {
+        "a": {
+            "$ref": "#/definitions/MyInterface"
+        },
+        "b": {
+            "$ref": "#/definitions/MyInterface_1"
+        },
+        "c": {
+            "$ref": "#/definitions/MyInterface_2"
+        }
+    },
+    "required": [
+        "a",
+        "b",
+        "c"
+    ],
+    "type": "object"
+}
+

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -108,6 +108,8 @@ describe("schema", () => {
     assertSchema("force-type", "main.ts", "MyObject");
     assertSchema("force-type-imported", "main.ts", "MyObject");
 
+    assertSchema("imports", "main.ts", "MyObject");
+
     /**
      * Type aliases
      */


### PR DESCRIPTION
Fixes problem with "imports" where if a type was declared in the main file, and one existed in another file with the same name, only the first would be created in the schema (see the test).