### PR TITLE
Allowing non-standard names for `tsconfig.json`

### DIFF
--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -7,7 +7,7 @@ import * as stringify from "json-stable-stringify";
 const vm = require("vm");
 
 const REGEX_FILE_NAME = /".*"\./;
-const REGEX_TSCONFIG_NAME = /^tsconfig.*\.json$/;
+const REGEX_TSCONFIG_NAME = /^.*\.json$/;
 const REGEX_TJS_JSDOC = /^-([\w]+)\s([\w-]+)/g;
 
 export function getDefaultArgs(): Args {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -7,6 +7,7 @@ import * as stringify from "json-stable-stringify";
 const vm = require("vm");
 
 const REGEX_FILE_NAME = /".*"\./;
+const REGEX_TSCONFIG_NAME = /^tsconfig.*\.json$/;
 const REGEX_TJS_JSDOC = /^-([\w]+)\s([\w-]+)/g;
 
 export function getDefaultArgs(): Args {
@@ -957,7 +958,7 @@ export function programFromConfig(configFileName: string): ts.Program {
 
 export function exec(filePattern: string, fullTypeName: string, args = getDefaultArgs()) {
     let program: ts.Program;
-    if (path.basename(filePattern) === "tsconfig.json") {
+    if (REGEX_TSCONFIG_NAME.test(path.basename(filePattern))) {
         program = programFromConfig(filePattern);
     } else {
         program = getProgramFromFiles(glob.sync(filePattern), {


### PR DESCRIPTION
This simply replaces the previous strict check (`name === "tsconfig.json"`) with a more relaxed check that simply ensures that the name begins with `tsconfig` and ends in `.json`. This is required in the case of e.g. Angular applications that use names like `tsconfig.app.json` and `tsconfig.spec.json` (see #120).

I have no idea how to properly test this, as the current testing infrastructure only seems to work directly with `.ts` files. The regex still matches `tsconfig.json` though, and I would not expect it to break any existing configurations as `.json` was never a allowed ending for source files.