### PR TITLE
[Fixes #106] Don't add ignored properties to "required" arrays

### DIFF
--- a/test/programs/ignored-required/main.ts
+++ b/test/programs/ignored-required/main.ts
@@ -1,0 +1,14 @@
+interface MyObject {
+    /**
+     * @ignore
+     */
+    ignored: boolean;
+
+    /**
+     * @ignore
+     */
+    ignoredOptional?: boolean;
+    
+    required: boolean;
+    optional?: boolean;
+}

--- a/test/programs/ignored-required/schema.json
+++ b/test/programs/ignored-required/schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+    "required": {
+      "type": "boolean"
+    },
+    "optional": {
+      "type": "boolean"
+    }
+  },
+  "required": [
+        "required"
+    ],
+  "type": "object"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -69,6 +69,8 @@ describe("schema", () => {
     assertSchema("class-single", "main.ts", "MyObject");
     assertSchema("class-extends", "main.ts", "MyObject");
 
+    assertSchema("ignored-required", "main.ts", "MyObject");
+
     assertSchema("interface-single", "main.ts", "MyObject");
     assertSchema("interface-multi", "main.ts", "MyObject");
     assertSchema("interface-extends", "main.ts", "MyObject");

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -584,7 +584,11 @@ export class JsonSchemaGenerator {
             }
             if (this.args.generateRequired) {
                 const requiredProps = props.reduce((required: string[], prop: ts.Symbol) => {
-                    if (!(prop.flags & ts.SymbolFlags.Optional) && !(<any>prop).mayBeUndefined) {
+                    if (!(prop.flags & ts.SymbolFlags.Optional)
+                        && !(<any>prop).mayBeUndefined
+                        && prop["tags"].find((x: any): boolean => {
+                            return x.name === "ignore";
+                        }) === undefined) {
                         required.push(prop.getName());
                     }
                     return required;

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -584,11 +584,9 @@ export class JsonSchemaGenerator {
             }
             if (this.args.generateRequired) {
                 const requiredProps = props.reduce((required: string[], prop: ts.Symbol) => {
-                    if (!(prop.flags & ts.SymbolFlags.Optional)
-                        && !(<any>prop).mayBeUndefined
-                        && prop["tags"].find((x: any): boolean => {
-                            return x.name === "ignore";
-                        }) === undefined) {
+                    let def = {};
+                    this.parseCommentsIntoDefinition(prop, def, {});
+                    if (!(prop.flags & ts.SymbolFlags.Optional) && !(<any>prop).mayBeUndefined && !def.hasOwnProperty("ignore")) {
                         required.push(prop.getName());
                     }
                     return required;


### PR DESCRIPTION
This PR stops ignored properties from being added to the "required" arrays in generated schemas.

We do this by replacing the conditional 
```
if (!(prop.flags & ts.SymbolFlags.Optional) && !(<any>prop).mayBeUndefined) {
    required.push(prop.getName());
}
```
with the following, stricter one:
```
if (!(prop.flags & ts.SymbolFlags.Optional)
    && !(<any>prop).mayBeUndefined
    && prop['tags'].find((x: any) : boolean => { 
    return x.name === 'ignore';
}) === undefined) {
    required.push(prop.getName());
}
```