### PR TITLE
Issue #131 add support for $ref annotation

### DIFF
--- a/test/programs/annotation-ref/main.ts
+++ b/test/programs/annotation-ref/main.ts
@@ -1,0 +1,13 @@
+interface MySubObject {}
+
+interface MyObject {
+    /**
+     * @$ref http://my-schema.org
+     */
+    externalRef;
+
+    /**
+     * @$ref http://my-schema.org
+     */
+    externalRefOverride: MySubObject;
+}

--- a/test/programs/annotation-ref/schema.json
+++ b/test/programs/annotation-ref/schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "definitions": {
+    "MySubObject": {
+      "type": "object"
+    }
+  },
+  "properties": {
+    "externalRef": {
+      "$ref": "http://my-schema.org"
+    },
+    "externalRefOverride": {
+      "$ref": "http://my-schema.org"
+    }
+  },
+  "required": [
+    "externalRef",
+    "externalRefOverride"
+  ]
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -175,6 +175,8 @@ describe("schema", () => {
      */
 
     assertSchema("annotation-default", "main.ts", "MyObject");
+    assertSchema("annotation-ref", "main.ts", "MyObject");
+    assertSchema("annotation-tjs", "main.ts", "MyObject");
 
     assertSchema("typeof-keyword", "main.ts", "MyObject", {useTypeOfKeyword: true});
 

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -155,7 +155,8 @@ export class JsonSchemaGenerator {
         ignore: true,
         description: true,
         format: true,
-        default: true
+        default: true,
+        $ref: true
     };
 
     private allSymbols: { [name: string]: ts.Type };


### PR DESCRIPTION
I want to be able to specify an external reference in my schema. Doing it with an annotation like this seems like the simplest way, but it does override any value for $ref that it would otherwise have, as you can see in the test. Please let me know if this is acceptable or if there's a better approach.