### PR TITLE
Add support for `object` type

### DIFF
--- a/test/programs/type-primitives/main.ts
+++ b/test/programs/type-primitives/main.ts
@@ -20,5 +20,6 @@ class MyObject {
 
     object1: any          = null;
     object2: {}           = null;
+    object3: object       = null;
 
 }

--- a/test/programs/type-primitives/schema.json
+++ b/test/programs/type-primitives/schema.json
@@ -39,6 +39,13 @@
             },
             "type": "object"
         },
+        "object3": {
+            "default": null,
+            "properties": {
+            },
+            "additionalProperties": true,
+            "type": "object"
+        },
         "string1": {
             "default": "defaultValue",
             "type": "string"
@@ -53,6 +60,7 @@
         "number1",
         "object1",
         "object2",
+        "object3",
         "string1"
     ],
     "type": "object"

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -379,6 +379,10 @@ export class JsonSchemaGenerator {
             } else if (propertyTypeString === "Date") {
                 definition.type = "string";
                 definition.format = "date-time";
+            }  else if (propertyTypeString === "object") {
+                definition.type = "object";
+                definition.properties = {};
+                definition.additionalProperties = true;
             } else {
                 const value = extractLiteralValue(propertyType);
                 if (value !== undefined) {


### PR DESCRIPTION
Adds support for the `object` type introduced in TypeScript 2.2. 
Please:
- [x] Do not include the compiled `.js`, `.js.map`, or `.d.ts` in your pull request as it makes it harder to merge your changes. 
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`
