### PR TITLE
Fix regex bug for "@TJS-pattern"

### DIFF
--- a/test/programs/annotation-tjs/main.ts
+++ b/test/programs/annotation-tjs/main.ts
@@ -49,4 +49,14 @@ interface MyObject {
      * @TJS-pattern ^[a-zA-Z0-9]{4}-abc_123$
      */
     regexPattern: string;
+
+    /**
+     * @TJS-pattern ^[a-zA-Z0-9]{4}-abc_123$    
+     */
+    regexPatternWithWhitespace: string;
+
+    /**
+     * @TJS-minimum 5
+     */
+    oneCharacter: number;
 }

--- a/test/programs/annotation-tjs/main.ts
+++ b/test/programs/annotation-tjs/main.ts
@@ -44,4 +44,9 @@ interface MyObject {
      * @TJS-format json-pointer
      */
     jsonPointer: string;
+
+    /**
+     * @TJS-pattern ^[a-zA-Z0-9]{4}-abc_123$
+     */
+    regexPattern: string;
 }

--- a/test/programs/annotation-tjs/schema.json
+++ b/test/programs/annotation-tjs/schema.json
@@ -25,7 +25,15 @@
             "format": "json-pointer",
             "type": "string"
         },
+        "oneCharacter": {
+            "minimum": 5,
+            "type": "number"
+        },
         "regexPattern": {
+            "pattern": "^[a-zA-Z0-9]{4}-abc_123$",
+            "type": "string"
+        },
+        "regexPatternWithWhitespace": {
             "pattern": "^[a-zA-Z0-9]{4}-abc_123$",
             "type": "string"
         },
@@ -49,7 +57,9 @@
         "ipv4",
         "ipv6",
         "jsonPointer",
+        "oneCharacter",
         "regexPattern",
+        "regexPatternWithWhitespace",
         "uri",
         "uriReference",
         "uriTemplate"

--- a/test/programs/annotation-tjs/schema.json
+++ b/test/programs/annotation-tjs/schema.json
@@ -25,6 +25,10 @@
             "format": "json-pointer",
             "type": "string"
         },
+        "regexPattern": {
+            "pattern": "^[a-zA-Z0-9]{4}-abc_123$",
+            "type": "string"
+        },
         "uri": {
             "format": "uri",
             "type": "string"
@@ -45,6 +49,7 @@
         "ipv4",
         "ipv6",
         "jsonPointer",
+        "regexPattern",
         "uri",
         "uriReference",
         "uriTemplate"

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -9,7 +9,7 @@ const vm = require("vm");
 
 const REGEX_FILE_NAME = /".*"\./;
 const REGEX_TSCONFIG_NAME = /^.*\.json$/;
-const REGEX_TJS_JSDOC = /^-([\w]+)\s([\w-]+)/g;
+const REGEX_TJS_JSDOC = /^-([\w]+)\s+(\S[\s\S]+)$/g;
 
 export function getDefaultArgs(): Args {
     return {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -9,7 +9,7 @@ const vm = require("vm");
 
 const REGEX_FILE_NAME = /".*"\./;
 const REGEX_TSCONFIG_NAME = /^.*\.json$/;
-const REGEX_TJS_JSDOC = /^-([\w]+)\s+(\S[\s\S]*\S)\s*$/g;
+const REGEX_TJS_JSDOC = /^-([\w]+)\s+(\S|\S[\s\S]*\S)\s*$/g;
 
 export function getDefaultArgs(): Args {
     return {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -9,7 +9,7 @@ const vm = require("vm");
 
 const REGEX_FILE_NAME = /".*"\./;
 const REGEX_TSCONFIG_NAME = /^.*\.json$/;
-const REGEX_TJS_JSDOC = /^-([\w]+)\s+(\S[\s\S]+)$/g;
+const REGEX_TJS_JSDOC = /^-([\w]+)\s+(\S[\s\S]*\S)\s*$/g;
 
 export function getDefaultArgs(): Args {
     return {


### PR DESCRIPTION
Currently, this causes a fatal error:
```typescript
export interface Foobar {
  /**
   * This foo describes my bar
   * @TJS-pattern ^[somefunregex]+$
   */
  foo: string;
}
```

This is due to the regex for `REGEX_TJS_JSDOC` being too restrictive.  While I realize that in the case of `@TJS-pattern` a simple `@pattern` could easily be substituted, it seems like the `TJS-` prefix should maintain consistent behavior across all JSON Schema tags.