### PR TITLE
Update Typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "dependencies": {
     "glob": "~7.1.2",
     "json-stable-stringify": "^1.0.1",
-    "typescript": "~2.5.3",
+    "typescript": "~2.6.2",
     "yargs": "^8.0.2"
   },
   "devDependencies": {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -997,7 +997,7 @@ export function programFromConfig(configFileName: string): ts.Program {
     const result = ts.parseConfigFileTextToJson(configFileName, ts.sys.readFile(configFileName)!);
     const configObject = result.config;
 
-    const configParseResult = ts.parseJsonConfigFileContent(configObject, ts.sys, path.dirname(configFileName), {}, configFileName);
+    const configParseResult = ts.parseJsonConfigFileContent(configObject, ts.sys, path.dirname(configFileName), {}, path.basename(configFileName));
     const options = configParseResult.options;
     options.noEmit = true;
     delete options.out;

--- a/yarn.lock
+++ b/yarn.lock
@@ -781,9 +781,9 @@ type-detect@^4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.3.tgz#0e3f2670b44099b0b46c284d136a7ef49c74c2ea"
 
-typescript@~2.5.3:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.5.3.tgz#df3dcdc38f3beb800d4bc322646b04a3f6ca7f0d"
+typescript@~2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
 
 v8flags@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Differences in how TS 2.6 and 2.5 infer types meant that I'd get compile errors in one version and not the other.

Modified typescript-json-schema to handle path behavior change in parseJsonConfigFileContent

Please:
- [x] Do not include the compiled `.js`, `.js.map`, or `.d.ts` in your pull request as it makes it harder to merge your changes. 
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`
