### PR TITLE
add support for mapped types

### DIFF
--- a/test/programs/type-mapped-types/main.ts
+++ b/test/programs/type-mapped-types/main.ts
@@ -1,0 +1,5 @@
+type Keys = 'str1' | 'str2';
+
+type MyMappedType = {
+  [key in Keys]: string;
+};

--- a/test/programs/type-mapped-types/main.ts
+++ b/test/programs/type-mapped-types/main.ts
@@ -1,4 +1,4 @@
-type Keys = 'str1' | 'str2';
+type Keys = "str1" | "str2";
 
 type MyMappedType = {
   [key in Keys]: string;

--- a/test/programs/type-mapped-types/schema.json
+++ b/test/programs/type-mapped-types/schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "properties": {
+      "str1": {
+          "type": "string"
+      },
+      "str2": {
+          "type": "string"
+      }
+  },
+  "required": [
+      "str1",
+      "str2"
+  ],
+  "type": "object"
+}
+

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -103,7 +103,7 @@ describe("schema", () => {
             topRef: true
         });
 
-        assertSchema('type-mapped-types', "MyMappedType");
+        assertSchema("type-mapped-types", "MyMappedType");
 
         /*
         assertSchema("type-aliases-primitive", "MyString");

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -103,6 +103,8 @@ describe("schema", () => {
             topRef: true
         });
 
+        assertSchema('type-mapped-types', "MyMappedType");
+
         /*
         assertSchema("type-aliases-primitive", "MyString");
         assertSchema("type-aliases-object", "MyAlias");

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -814,7 +814,7 @@ export class JsonSchemaGenerator {
                     this.getDefinitionForRootType(typ, tc, reffedType!, definition);
                 } else if (node && (node.kind === ts.SyntaxKind.EnumDeclaration || node.kind === ts.SyntaxKind.EnumMember)) {
                     this.getEnumDefinition(typ, tc, definition);
-                } else if (symbol && symbol.flags & ts.SymbolFlags.TypeLiteral && symbol.members!.size === 0) {
+                } else if (symbol && symbol.flags & ts.SymbolFlags.TypeLiteral && symbol.members!.size === 0 && !(node && (node.kind === ts.SyntaxKind.MappedType))) {
                     // {} is TypeLiteral with no members. Need special case because it doesn't have declarations.
                     definition.type = "object";
                     definition.properties = {};


### PR DESCRIPTION
Add support for Mapped Types.

For example:

```ts
type ValidKeys = 'foo' | 'bar' | 'baz';

type KeyMap = {
  [key in ValidKeys]: string;
}
```

Please:
- [x] Do not include the compiled `.js`, `.js.map`, or `.d.ts` in your pull request as it makes it harder to merge your changes. 
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`
