### PR TITLE
Convert compiler options from JSON format to Typescript format, adding an optional argument for base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,10 @@ const compilerOptions: TJS.CompilerOptions = {
     strictNullChecks: true
 }
 
-const program = TJS.getProgramFromFiles([resolve("my-file.ts")], compilerOptions);
+// optionally pass a base path
+const basePath = "./my-dir";
+
+const program = TJS.getProgramFromFiles([resolve("my-file.ts")], compilerOptions, basePath);
 
 // We can either get the schema for one file and one type...
 const schema = TJS.generateSchema(program, "MyType", settings);

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -886,8 +886,9 @@ export class JsonSchemaGenerator {
     }
 }
 
-export function getProgramFromFiles(files: string[], compilerOptions: ts.CompilerOptions = {}): ts.Program {
+export function getProgramFromFiles(files: string[], jsonCompilerOptions: any = {}, basePath: string = "./"): ts.Program {
     // use built-in default options
+    const compilerOptions = ts.convertCompilerOptionsFromJson(jsonCompilerOptions, basePath).options;
     const options: ts.CompilerOptions = {
         noEmit: true, emitDecoratorMetadata: true, experimentalDecorators: true, target: ts.ScriptTarget.ES5, module: ts.ModuleKind.CommonJS
     };


### PR DESCRIPTION
The base path was added to provide flexibility for programmatic users, however I could remove it.
I had a look at tests and couldn't see any obvious place to add one. Any suggestions?