### PR TITLE
Fix not being able to get default types when using type assertions

### DIFF
--- a/test/programs/default-properties/main.ts
+++ b/test/programs/default-properties/main.ts
@@ -1,0 +1,7 @@
+type Foo = "a" | "b" | "c" | boolean | number;
+
+class MyObject {
+    varBoolean: Foo = <any> false;
+    varInteger: Foo = <any> 123;
+    varString: Foo = <any> "123";
+}

--- a/test/programs/default-properties/schema.json
+++ b/test/programs/default-properties/schema.json
@@ -1,0 +1,62 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "properties": {
+        "varBoolean": {
+            "anyOf": [
+                {
+                    "enum": [
+                        "a",
+                        "b",
+                        "c",
+                        false,
+                        true
+                    ]
+                },
+                {
+                    "type": "number"
+                }
+            ],
+            "default": false
+        },
+        "varInteger": {
+            "anyOf": [
+                {
+                    "enum": [
+                        "a",
+                        "b",
+                        "c",
+                        false,
+                        true
+                    ]
+                },
+                {
+                    "type": "number"
+                }
+            ],
+            "default": 123
+        },
+        "varString": {
+            "anyOf": [
+                {
+                    "enum": [
+                        "a",
+                        "b",
+                        "c",
+                        false,
+                        true
+                    ]
+                },
+                {
+                    "type": "number"
+                }
+            ],
+            "default": "123"
+        }
+    },
+    "required": [
+        "varBoolean",
+        "varInteger",
+        ",varString"
+    ],
+    "type": "object"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -195,6 +195,8 @@ describe("schema", () => {
 
         assertSchema("ignored-required", "MyObject");
 
+        assertSchema("default-properties", "MyObject");
+
         // not supported yet #116
         // assertSchema("interface-extra-props", "MyObject");
 

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -362,7 +362,12 @@ export class JsonSchemaGenerator {
         // try to get default value
         let valDecl = prop.valueDeclaration as ts.VariableDeclaration;
         if (valDecl && valDecl.initializer) {
-            const initial = valDecl.initializer;
+            let initial = valDecl.initializer;
+
+            while (ts.isTypeAssertion(initial)) {
+                initial = initial.expression;
+            }
+
             if ((<any>initial).expression) { // node
                 console.warn("initializer is expression for property " + propertyName);
             } else if ((<any>initial).kind && (<any>initial).kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral) {


### PR DESCRIPTION
Please:
- [x] Do not include the compiled `.js`, `.js.map`, or `.d.ts` in your pull request as it makes it harder to merge your changes. 
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`

Using a type assertion in a property declaration causes it to be unable to resolve the type. 