### PR TITLE
Add --include flag: further limits files from tsconfig.json.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ test/*.map
 .vscode/*.*
 npm-debug.log
 .idea
+*~
+.#*

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Generate json-schemas from your Typescript sources.
 * Generate schema from a typescript type: `typescript-json-schema project/directory/tsconfig.json TYPE`
 
 To generate files for only _some_ types in `tsconfig.json` specify
-filenames or globs with the `--include` option.
+filenames or globs with the `--include` option. This is especially useful for large projects.
 
 In case no `tsconfig.json` is available for your project, you can directly specify the .ts files (this in this case we use some built-in compiler presets):
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Generate json-schemas from your Typescript sources.
 * Install with `npm install typescript-json-schema -g`
 * Generate schema from a typescript type: `typescript-json-schema project/directory/tsconfig.json TYPE`
 
+To generate files for only _some_ types in `tsconfig.json` specify
+filenames or globs with the `--include` option.
+
 In case no `tsconfig.json` is available for your project, you can directly specify the .ts files (this in this case we use some built-in compiler presets):
 
 * Generate schema from a typescript type: `typescript-json-schema "project/directory/**/*.ts" TYPE`
@@ -38,6 +41,7 @@ Options:
   --useTypeOfKeyword    Use `typeOf` keyword (https://goo.gl/DC6sni) for functions.  [boolean] [default: false]
   --out, -o             The output file, defaults to using stdout
   --validationKeywords  Provide additional validation keywords to include            [array]   [default: []]
+  --include             Further limit tsconfig to include only matching files        [array]   [default: []]
   --ignoreErrors        Generate even if the program has errors.                     [boolean] [default: false]
   --excludePrivate      Exclude private members from the schema                      [boolean] [default: false]
 ```

--- a/test/programs/tsconfig/exclude.ts
+++ b/test/programs/tsconfig/exclude.ts
@@ -1,0 +1,5 @@
+// This file is ignored.
+
+export interface Excluded {
+    a: string;
+}

--- a/test/programs/tsconfig/includedAlways.ts
+++ b/test/programs/tsconfig/includedAlways.ts
@@ -1,0 +1,5 @@
+// This file is included by tsconfig.json and --include.
+
+export interface IncludedAlways {
+    a: string;
+};

--- a/test/programs/tsconfig/includedByConfig.ts
+++ b/test/programs/tsconfig/includedByConfig.ts
@@ -1,0 +1,5 @@
+// This file is included by tsconfig.json.
+
+export interface IncludedOnlyByTsConfig {
+    a: string;
+};

--- a/test/programs/tsconfig/tsconfig.json
+++ b/test/programs/tsconfig/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+    },
+    "include": [
+        "**/include*.ts",
+    ]
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -243,3 +243,30 @@ describe("schema", () => {
         assertSchema("builtin-names", "Ext.Foo");
     });
 });
+
+describe("tsconfig.json", () => {
+    it("should read files from tsconfig.json", () => {
+        const program = TJS.programFromConfig(resolve(BASE + "tsconfig/tsconfig.json"));
+        const generator = TJS.buildGenerator(program);
+        assert(generator !== null);
+        assert.instanceOf(generator, TJS.JsonSchemaGenerator);
+        if (generator !== null) {
+            assert.doesNotThrow(() => generator.getSchemaForSymbol("IncludedAlways"));
+            assert.doesNotThrow(() => generator.getSchemaForSymbol("IncludedOnlyByTsConfig"));
+            assert.throws(() => generator.getSchemaForSymbol("Excluded"));
+        }
+    });
+    it("should support includeOnlyFiles with tsconfig.json", () => {
+        const program = TJS.programFromConfig(
+            resolve(BASE + "tsconfig/tsconfig.json"), [resolve(BASE + "tsconfig/includedAlways.ts")]
+        );
+        const generator = TJS.buildGenerator(program);
+        assert(generator !== null);
+        assert.instanceOf(generator, TJS.JsonSchemaGenerator);
+        if (generator !== null) {
+            assert.doesNotThrow(() => generator.getSchemaForSymbol("IncludedAlways"));
+            assert.throws(() => generator.getSchemaForSymbol("Excluded"));
+            assert.throws(() => generator.getSchemaForSymbol("IncludedOnlyByTsConfig"));
+        }
+    });
+});

--- a/typescript-json-schema-cli.ts
+++ b/typescript-json-schema-cli.ts
@@ -32,6 +32,8 @@ export function run() {
             .describe("out", "The output file, defaults to using stdout")
         .array("validationKeywords").default("validationKeywords", defaultArgs.validationKeywords)
             .describe("validationKeywords", "Provide additional validation keywords to include.")
+        .array("include").default("*", defaultArgs.include)
+            .describe("include", "Further limit tsconfig to include only matching files.")
         .argv;
 
     exec(args._[0], args._[1], {
@@ -48,6 +50,7 @@ export function run() {
         ignoreErrors: args.ignoreErrors,
         out: args.out,
         validationKeywords: args.validationKeywords,
+        include: args.include,
         excludePrivate: args.excludePrivate,
     });
 }

--- a/typescript-json-schema.d.ts
+++ b/typescript-json-schema.d.ts
@@ -18,6 +18,7 @@ export declare type Args = {
     ignoreErrors: boolean;
     out: string;
     validationKeywords: string[];
+    include: string[];
     excludePrivate: boolean;
 };
 export declare type PartialArgs = Partial<Args>;
@@ -90,5 +91,5 @@ export declare class JsonSchemaGenerator {
 export declare function getProgramFromFiles(files: string[], jsonCompilerOptions?: any, basePath?: string): ts.Program;
 export declare function buildGenerator(program: ts.Program, args?: PartialArgs): JsonSchemaGenerator | null;
 export declare function generateSchema(program: ts.Program, fullTypeName: string, args?: PartialArgs, onlyIncludeFiles?: string[]): Definition | null;
-export declare function programFromConfig(configFileName: string): ts.Program;
+export declare function programFromConfig(configFileName: string, onlyIncludeFiles?: string[]): ts.Program;
 export declare function exec(filePattern: string, fullTypeName: string, args?: Args): void;

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1113,8 +1113,6 @@ export function exec(filePattern: string, fullTypeName: string, args = getDefaul
     let program: ts.Program;
     let onlyIncludeFiles: string[] | undefined = undefined;
     if (REGEX_TSCONFIG_NAME.test(path.basename(filePattern))) {
-        let onlyIncludeFiles: string[] | undefined;
-
         if (args.include.length > 0) {
             const globs: string[][] = args.include.map(f => glob.sync(f));
             onlyIncludeFiles = ([] as string[]).concat(...globs).map(normalizeFileName);


### PR DESCRIPTION
In a large project, it is slow and not needed to extract schemata from
all TypeScript files in `tsconfig.json` (also it can be infeasible due
to limitations of what can be converted to JSON schema).  OTOH listing
the files as the command-line argument ignores all the parameters from
`tsconfig.json`.  `--include` gets us the advantages of both.

Tests for --include flag (and programFromConfig).

Please:
- [v ] Do not include the compiled `.js`, `.js.map`, or `.d.ts` in your pull request as it makes it harder to merge your changes. 
- [ v] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [v ] Provide a test case & update the documentation in the `Readme.md`
