### PR TITLE
Fixes #215 (crash calling 'length' of undefined)

### DIFF
--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1135,7 +1135,7 @@ export function exec(filePattern: string, fullTypeName: string, args = getDefaul
     let program: ts.Program;
     let onlyIncludeFiles: string[] | undefined = undefined;
     if (REGEX_TSCONFIG_NAME.test(path.basename(filePattern))) {
-        if (args.include.length > 0) {
+        if (args.include && args.include.length > 0) {
             const globs: string[][] = args.include.map(f => glob.sync(f));
             onlyIncludeFiles = ([] as string[]).concat(...globs).map(normalizeFileName);
         }


### PR DESCRIPTION
Fixes #215.

Please:
- [x] Do not include the compiled `.js`, `.js.map`, or `.d.ts` in your pull request as it makes it harder to merge your changes. 
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`
