### PR TITLE
buildGenerator performance improvement (avoid unnecessary work)

### DIFF
--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1029,11 +1029,14 @@ export function buildGenerator(program: ts.Program, args: PartialArgs = {}): Jso
         }
     }
 
-    const typeChecker = program.getTypeChecker();
+    let diagnostics: Array<ts.Diagnostic> = [];
 
-    var diagnostics = ts.getPreEmitDiagnostics(program);
+    if (!args.ignoreErrors) {
+        diagnostics = ts.getPreEmitDiagnostics(program);
+    }
 
-    if (diagnostics.length === 0 || args.ignoreErrors) {
+    if (diagnostics.length === 0) {
+        const typeChecker = program.getTypeChecker();
 
         const symbols: SymbolRef[] = [];
         const allSymbols: { [name: string]: ts.Type } = {};


### PR DESCRIPTION
- don't get type checker if we will not use it
- don't get diagnostics if we will ignore them anyway

This performance improvement is relevant for my programmatic use case.

Note: I got 1 failed test both before and after my change. Details:

  1) schema
       other
         unique-names should create correct schema:
     Error: ENOENT: no such file or directory, open 'C:\Users\********\git\typesc
ript-json-schema\test\programs\unique-names\schema.MyObject.2219977.json'
      at Object.fs.openSync (fs.js:646:18)
      at Object.fs.readFileSync (fs.js:551:33)
      at Context.<anonymous> (test\schema.test.ts:55:24)

Please:
- [x] Do not include the compiled `.js`, `.js.map`, or `.d.ts` in your pull request as it makes it harder to merge your changes. 
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [ ] Provide a test case & update the documentation in the `Readme.md`
