### PR TITLE
Really include only requested files

### DIFF
--- a/test/programs/user-symbols/main.ts
+++ b/test/programs/user-symbols/main.ts
@@ -1,0 +1,3 @@
+export interface Context {
+  ip: string;
+}

--- a/test/programs/user-symbols/schema.json
+++ b/test/programs/user-symbols/schema.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "definitions": {
+        "Context": {
+            "properties": {
+                "ip": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "ip"
+            ],
+            "type": "object"
+        }
+    }
+}
+

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -19,7 +19,8 @@ export function assertSchema(group: string, type: string, settings: TJS.PartialA
             settings.required = true;
         }
 
-        const actual = TJS.generateSchema(TJS.getProgramFromFiles([resolve(BASE + group + "/main.ts")], compilerOptions), type, settings);
+        const files = [resolve(BASE + group + "/main.ts")];
+        const actual = TJS.generateSchema(TJS.getProgramFromFiles(files, compilerOptions), type, settings, files);
 
         // writeFileSync(BASE + group + "/schema.json", stringify(actual, {space: 4}) + "\n\n");
 
@@ -275,6 +276,8 @@ describe("schema", () => {
         });
 
         assertSchema("builtin-names", "Ext.Foo");
+
+        assertSchema("user-symbols", "*");
     });
 });
 


### PR DESCRIPTION
This is better than what we had before, now `tjs` will prefer included files over a project dependency.
It's still not a perfect solution though.