### PR TITLE
added argument for $id in schema object

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Options:
   --ignoreErrors        Generate even if the program has errors.                     [boolean] [default: false]
   --excludePrivate      Exclude private members from the schema                      [boolean] [default: false]
   --uniqueNames         Use unique names for type symbols.                           [boolean] [default: false]
+  --id                  Set schema id.                                               [string] [default: ""]
 ```
 
 ### Programmatic use

--- a/test/programs/argument-id/main.ts
+++ b/test/programs/argument-id/main.ts
@@ -1,0 +1,8 @@
+interface MyObject {
+    someProp: string;
+    referenceType: ReferenceType;
+}
+
+interface ReferenceType {
+    reference: true;
+}

--- a/test/programs/argument-id/schema.MyObject.json
+++ b/test/programs/argument-id/schema.MyObject.json
@@ -1,0 +1,33 @@
+{
+    "$id": "someSchemaId",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "ReferenceType": {
+            "properties": {
+                "reference": {
+                    "enum": [
+                        true
+                    ],
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "reference"
+            ],
+            "type": "object"
+        }
+    },
+    "properties": {
+        "referenceType": {
+            "$ref": "someSchemaId#/definitions/ReferenceType"
+        },
+        "someProp": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "referenceType",
+        "someProp"
+    ],
+    "type": "object"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -275,6 +275,10 @@ describe("schema", () => {
         assertSchema("builtin-names", "Ext.Foo");
 
         assertSchema("user-symbols", "*");
+
+        assertSchemas("argument-id", "MyObject", {
+            id: "someSchemaId"
+        });
     });
 });
 

--- a/typescript-json-schema-cli.ts
+++ b/typescript-json-schema-cli.ts
@@ -38,6 +38,8 @@ export function run() {
             .describe("uniqueNames", "Use unique names for type symbols.")
         .array("include").default("*", defaultArgs.include)
             .describe("include", "Further limit tsconfig to include only matching files.")
+        .string("id").default("id", defaultArgs.id)
+            .describe("id", "ID of schema.")
         .argv;
 
     exec(args._[0], args._[1], {
@@ -57,6 +59,7 @@ export function run() {
         include: args.include,
         excludePrivate: args.excludePrivate,
         uniqueNames: args.uniqueNames,
+        id: args.id
     });
 }
 

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -29,6 +29,7 @@ export function getDefaultArgs(): Args {
         include: [],
         excludePrivate: false,
         uniqueNames: false,
+        id: ""
     };
 }
 
@@ -53,6 +54,7 @@ export type Args = {
     include: string[];
     excludePrivate: boolean;
     uniqueNames: boolean;
+    id: string;
 };
 
 export type PartialArgs = Partial<Args>;
@@ -62,6 +64,7 @@ export type PrimitiveType = number | boolean | string | null;
 export type Definition = {
     $ref?: string,
     $schema?: string,
+    $id?: string,
     description?: string,
     allOf?: Definition[],
     oneOf?: Definition[],
@@ -859,7 +862,7 @@ export class JsonSchemaGenerator {
             // We don't return the full definition, but we put it into
             // reffedDefinitions below.
             returnedDefinition = {
-                $ref:  "#/definitions/" + fullTypeName
+                $ref:  `${this.args.id}#/definitions/` + fullTypeName
             };
         }
 
@@ -951,12 +954,14 @@ export class JsonSchemaGenerator {
             def.definitions = this.reffedDefinitions;
         }
         def["$schema"] = "http://json-schema.org/draft-07/schema#";
+        def["$id"] = this.args.id;
         return def;
     }
 
     public getSchemaForSymbols(symbolNames: string[], includeReffedDefinitions: boolean = true): Definition {
         const root = {
             $schema: "http://json-schema.org/draft-07/schema#",
+            $id: this.args.id,
             definitions: {}
         };
         for (const symbolName of symbolNames) {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -954,16 +954,24 @@ export class JsonSchemaGenerator {
             def.definitions = this.reffedDefinitions;
         }
         def["$schema"] = "http://json-schema.org/draft-07/schema#";
-        def["$id"] = this.args.id;
+        const id = this.args.id;
+        if(id) {
+            def["$id"] = this.args.id;
+        }
         return def;
     }
 
     public getSchemaForSymbols(symbolNames: string[], includeReffedDefinitions: boolean = true): Definition {
         const root = {
             $schema: "http://json-schema.org/draft-07/schema#",
-            $id: this.args.id,
             definitions: {}
         };
+        const id = this.args.id;
+
+        if(id) {
+            root["$id"] = id;
+        }
+
         for (const symbolName of symbolNames) {
             root.definitions[symbolName] = this.getTypeDefinition(this.allSymbols[symbolName], this.args.topRef, undefined, undefined, undefined, this.userSymbols[symbolName]);
         }


### PR DESCRIPTION
I'm going to use [ajv](https://github.com/epoberezkin/ajv) as validator, and for proper work of references it requires schema `$id`

I think it's what somebody wants here https://github.com/YousefED/typescript-json-schema/issues/183