### PR TITLE
Throw errors when problems happen so we get non-zero exit codes

### DIFF
--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import { exec, getDefaultArgs } from "../typescript-json-schema";
-import * as path from 'path';
+import * as path from "path";
 
 describe("error", () => {
     it("error-check", () => {

--- a/test/error.test.ts
+++ b/test/error.test.ts
@@ -1,0 +1,12 @@
+import { assert } from "chai";
+import { exec, getDefaultArgs } from "../typescript-json-schema";
+import * as path from 'path';
+
+describe("error", () => {
+    it("error-check", () => {
+        assert.throws(() => {
+            // This needs a valid path. "dates" chosen basically at random
+            exec(path.resolve(__dirname, "./programs/dates/"), "MyObject", getDefaultArgs());
+        }, Error, "No output definition. Probably caused by errors prior to this?");
+    });
+});

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1195,14 +1195,14 @@ export function exec(filePattern: string, fullTypeName: string, args = getDefaul
 
     const definition = generateSchema(program, fullTypeName, args, onlyIncludeFiles);
     if (definition === null) {
-        return;
+        throw new Error("No output definition. Probably caused by errors prior to this?");
     }
 
     const json = stringify(definition, {space: 4}) + "\n\n";
     if (args.out) {
         require("fs").writeFile(args.out, json, function(err: Error) {
             if (err) {
-                console.error("Unable to write output file: " + err.message);
+                throw new Error("Unable to write output file: " + err.message);
             }
         });
     } else {


### PR DESCRIPTION
Please:
- [x] Do not include the compiled `.js`, `.js.map`, or `.d.ts` in your pull request as it makes it harder to merge your changes. 
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`

Fixes #239
