### PR TITLE
resolved issue where schema gen would crash when using abstract classes

### DIFF
--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -723,7 +723,7 @@ export class JsonSchemaGenerator {
 
         const modifierFlags = ts.getCombinedModifierFlags(node);
 
-        if (modifierFlags & ts.ModifierFlags.Abstract) {
+        if (modifierFlags & ts.ModifierFlags.Abstract && this.inheritingTypes[fullName]) {
             const oneOf = this.inheritingTypes[fullName].map((typename) => {
                 return this.getTypeDefinition(this.allSymbols[typename]);
             });


### PR DESCRIPTION
Please:
- [ ] Do not include the compiled `.js`, `.js.map`, or `.d.ts` in your pull request as it makes it harder to merge your changes. 
- [ ] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [ ] Provide a test case & update the documentation in the `Readme.md`
