### PR TITLE
Ignore declarationMap option in TypeScript config.

### DIFF
--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1176,6 +1176,7 @@ export function programFromConfig(configFileName: string, onlyIncludeFiles?: str
     delete options.outDir;
     delete options.outFile;
     delete options.declaration;
+    delete options.declarationMap;
 
     const program = ts.createProgram(onlyIncludeFiles || configParseResult.fileNames, options);
     return program;


### PR DESCRIPTION
Using declarationMap option without declaration option (which is already ignored) results in error:
Option 'declarationMap' cannot be specified without specifying option 'declaration' or option 'composite'.