### PR TITLE
Fix an error where two different partial types get confused

### DIFF
--- a/test/programs/type-aliases-partial/main.ts
+++ b/test/programs/type-aliases-partial/main.ts
@@ -1,0 +1,14 @@
+export interface Foo {
+    x: number;
+    y: number;
+}
+
+export interface Bar {
+    a: number;
+    b: number;
+}
+
+export interface MyObject {
+    foo: Partial<Foo>;
+    bar: Partial<Bar>;
+}

--- a/test/programs/type-aliases-partial/schema.json
+++ b/test/programs/type-aliases-partial/schema.json
@@ -1,0 +1,46 @@
+{
+  "type": "object",
+  "properties": {
+    "foo": {
+      "$ref": "#/definitions/Partial"
+    },
+    "bar": {
+      "$ref": "#/definitions/Partial_1"
+    }
+  },
+  "required": [
+    "bar",
+    "foo"
+  ],
+  "definitions": {
+    "__type": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        }
+      }
+    },
+    "Partial": {
+      "$ref": "#/definitions/__type"
+    },
+    "__type_1": {
+      "type": "object",
+      "properties": {
+        "a": {
+          "type": "number"
+        },
+        "b": {
+          "type": "number"
+        }
+      }
+    },
+    "Partial_1": {
+      "$ref": "#/definitions/__type_1"
+    }
+  },
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -121,6 +121,10 @@ describe("schema", () => {
         assertSchema("type-aliases-fixed-size-array", "MyFixedSizeArray");
         assertSchema("type-aliases-multitype-array", "MyArray");
         assertSchema("type-aliases-local-namsepace", "MyObject", {
+            aliasRef: true,
+            strictNullChecks: true,
+        });
+        assertSchema("type-aliases-partial", "MyObject", {
             aliasRef: true
         });
 


### PR DESCRIPTION
Both these two types get the alias `Partial`, even though they have different strucutres.

Please:
- [x] Do not include the compiled `.js`, `.js.map`, or `.d.ts` in your pull request as it makes it harder to merge your changes. 
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`
