### PR TITLE
Advanced types - Exclude<T, S> should generate separate types in schema, if the arguments are different.

### DIFF
--- a/test/programs/exclude-unique-type/main.ts
+++ b/test/programs/exclude-unique-type/main.ts
@@ -1,0 +1,15 @@
+export interface IExcludeTest {
+    AB: IExcludeTestAB;
+    CD: IExcludeTestCD;
+}
+
+export interface IExcludeTestAB {
+    A: string;
+    B: string;
+    importantKey: Exclude<keyof IExcludeTestAB, "importantKey">;
+}
+export interface IExcludeTestCD {
+    C: string;
+    D: string;
+    importantKey: Exclude<keyof IExcludeTestCD, "importantKey">;
+}

--- a/test/programs/exclude-unique-type/main.ts
+++ b/test/programs/exclude-unique-type/main.ts
@@ -6,10 +6,18 @@ export interface IExcludeTest {
 export interface IExcludeTestAB {
     A: string;
     B: string;
+    /**
+     * importantKey should be "A" | "B"
+     */
     importantKey: Exclude<keyof IExcludeTestAB, "importantKey">;
 }
 export interface IExcludeTestCD {
     C: string;
     D: string;
+    /**
+     * importantKey should be "C" | "D"
+     * but schema generator generates single Exclude type for the whole jsonschema document.
+     * in the schema, here will be "A" | "B", which is not correct
+     */
     importantKey: Exclude<keyof IExcludeTestCD, "importantKey">;
 }


### PR DESCRIPTION
Advanced types - Exclude<T, S> should generate separate types in schema, if the arguments are different.

I just added here a test case.
For interface:

    export interface IExcludeTest {
        AB: IExcludeTestAB;
        CD: IExcludeTestCD;
    }

    export interface IExcludeTestAB {
        A: string;
        B: string;
        importantKey: Exclude<keyof IExcludeTestAB, "importantKey">;
    }
    export interface IExcludeTestCD {
        C: string;
        D: string;
        importantKey: Exclude<keyof IExcludeTestCD, "importantKey">;
    }

It will generate one type

    "Exclude": {
        "description": "Exclude from T those types that are assignable to U",
        "enum": [
            "A",
            "B"
        ],
        "type": "string"
    }

And reference it in both situations

    "importantKey": {
        "$ref": "#/definitions/Exclude"
    }


