### PR TITLE
feat: 🎸 allow namespaced versions of "Date"

### DIFF
--- a/test/programs/custom-dates/main.ts
+++ b/test/programs/custom-dates/main.ts
@@ -1,0 +1,11 @@
+namespace foo {
+  export interface Date {
+    day?: number;
+    month?: number;
+    year?: number;
+  }
+
+  export interface Bar {
+    date: Date;
+  }
+}

--- a/test/programs/custom-dates/schema.json
+++ b/test/programs/custom-dates/schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "foo.Date": {
+      "properties": {
+        "day": {
+          "type": "number"
+        },
+        "month": {
+          "type": "number"
+        },
+        "year": {
+          "type": "number"
+        }
+      },
+      "type": "object"
+    }
+  },
+  "properties": {
+     "date": {
+       "$ref": "#/definitions/foo.Date"
+     }
+  },
+  "required": [
+      "date"
+  ],
+  "type": "object"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -270,6 +270,10 @@ describe("schema", () => {
         assertSchema("string-literals-inline", "MyObject");
     });
 
+    describe("custom dates", () => {
+        assertSchema("custom-dates", "foo.Bar");
+    });
+
     describe("dates", () => {
         assertSchema("dates", "MyObject");
         assertRejection("dates", "MyObject", {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -858,7 +858,7 @@ export class JsonSchemaGenerator {
 
         const symbol = typ.getSymbol();
         // FIXME: We can't just compare the name of the symbol - it ignores the namespace
-        const isRawType = (!symbol || symbol.name === "Date" || symbol.name === "integer" || this.tc.getIndexInfoOfType(typ, ts.IndexKind.Number) !== undefined);
+        const isRawType = (!symbol || this.tc.getFullyQualifiedName(symbol) === "Date" || symbol.name === "integer" || this.tc.getIndexInfoOfType(typ, ts.IndexKind.Number) !== undefined);
 
         // special case: an union where all child are string literals -> make an enum instead
         let isStringEnum = false;


### PR DESCRIPTION
I'm trying to use this package to build schemas that include [gapi.client.people](https://github.com/DefinitelyTyped/DefinitelyTyped/tree/master/types/gapi.client.people) types.

[They use their own `Date` type](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/6a5529e838d9386fb6567296e84d945e25805281/types/gapi.client.people/index.d.ts#L182-L195):

```typescript
        interface Date {
            /**
             * Day of month. Must be from 1 to 31 and valid for the year and month, or 0
             * if specifying a year/month where the day is not significant.
             */
            day?: number;
            /** Month of year. Must be from 1 to 12. */
            month?: number;
            /**
             * Year of date. Must be from 1 to 9999, or 0 if specifying a date without
             * a year.
             */
            year?: number;
        }
```

This does not build with typescript-json-schema, as it considers any interface with a name of `Date` to be a native Date.

This pull request will look for a "full qualified name" of `Date` instead.