### PR TITLE
Ignore declarationDir option in TypeScript config

### DIFF
--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1183,6 +1183,7 @@ export function programFromConfig(configFileName: string, onlyIncludeFiles?: str
     delete options.outDir;
     delete options.outFile;
     delete options.declaration;
+    delete options.declarationDir;
     delete options.declarationMap;
 
     const program = ts.createProgram({


### PR DESCRIPTION
`declarationDir` should also be ignored, or the same error as noted in (#261) happens.

