### PR TITLE
Add support for unknown

### DIFF
--- a/test/programs/any-unknown/main.ts
+++ b/test/programs/any-unknown/main.ts
@@ -1,0 +1,4 @@
+export interface MyObject {
+    a: any;
+    b: unknown;
+}

--- a/test/programs/any-unknown/schema.json
+++ b/test/programs/any-unknown/schema.json
@@ -1,0 +1,13 @@
+{
+    "type": "object",
+    "properties": {
+        "a": {},
+        "b": {}
+    },
+    "required": [
+        "a",
+        "b"
+    ],
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}
+

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -229,6 +229,7 @@ describe("schema", () => {
         assertSchema("type-nullable", "MyObject");
         // see https://github.com/epoberezkin/ajv/issues/725
         // assertSchema("type-function", "MyObject");
+        assertSchema("any-unknown", "MyObject");
     });
 
     describe("class and interface", () => {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -407,7 +407,7 @@ export class JsonSchemaGenerator {
                 definition.type = "null";
             } else if (flags & ts.TypeFlags.Undefined) {
                 definition.type = "undefined";
-            } else if (flags & ts.TypeFlags.Any) {
+            } else if ((flags & ts.TypeFlags.Any) || (flags & ts.TypeFlags.Unknown)) {
                 // no type restriction, so that anything will match
             } else if (propertyTypeString === "Date" && !this.args.rejectDateType) {
                 definition.type = "string";


### PR DESCRIPTION
The `unknown` keyword is like a safe version of `any`. It does not verify anything about the value, but acts unlike `any`, it is a type error to assume anything about the value of an `unknown`.

Please:
- [x] Do not include the compiled `.js`, `.js.map`, or `.d.ts` in your pull request as it makes it harder to merge your changes. 
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`
