### PR TITLE
Asterisk to include all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In case no `tsconfig.json` is available for your project, you can directly speci
 
 * Generate schema from a typescript type: `typescript-json-schema "project/directory/**/*.ts" TYPE`
 
-The `TYPE` can either be a single, fully qualified type or `*` to generate the schema for all types. 
+The `TYPE` can either be a single, fully qualified type or `'*'` (with quotes) to generate the schema for all types. 
 
 ```
 Usage: typescript-json-schema <path-to-typescript-files-or-tsconfig> <type>


### PR DESCRIPTION
Please update the docs. I lost three hours because the * need to be '*'.
If you run the command with no quotes its try to scan the current folder where you execute the command.
