### PR TITLE
Use @types/json-schema definition for more standard json schema Defin…

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "schema"
   ],
   "dependencies": {
+    "@types/json-schema": "^7.0.3",
     "glob": "~7.1.4",
     "json-stable-stringify": "^1.0.1",
     "typescript": "^3.5.1",

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -70,12 +70,12 @@ type RedifinedFields = "type" | "items" | "additionalItems" | "contains" | "prop
 export type DefinitionOrBoolean = Definition | boolean;
 export interface Definition extends Omit<JSONSchema7, RedifinedFields> {
     // The type field here is incompatible with the standard definition
-    type?: string | string[],
+    type?: string | string[];
 
     // Non-standard fields
-    propertyOrder?: string[],
-    defaultProperties?: string[],
-    typeof?: "function",
+    propertyOrder?: string[];
+    defaultProperties?: string[];
+    typeof?: "function";
 
     // Fields that must be redifined because they make use of this definition itself
     items?: DefinitionOrBoolean | DefinitionOrBoolean[];
@@ -102,7 +102,7 @@ export interface Definition extends Omit<JSONSchema7, RedifinedFields> {
     definitions?: {
         [key: string]: DefinitionOrBoolean;
     };
-};
+}
 
 export type SymbolRef = {
   name: string;

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -3,6 +3,7 @@ import * as stringify from "json-stable-stringify";
 import * as path from "path";
 import { createHash } from "crypto";
 import * as ts from "typescript";
+import { JSONSchema7 } from "json-schema";
 export { Program, CompilerOptions, Symbol } from "typescript";
 
 
@@ -65,33 +66,42 @@ export type PartialArgs = Partial<Args>;
 
 export type PrimitiveType = number | boolean | string | null;
 
-export type Definition = {
-    $ref?: string,
-    $schema?: string,
-    $id?: string,
-    description?: string,
-    examples?: any[],
-    allOf?: Definition[],
-    oneOf?: Definition[],
-    anyOf?: Definition[],
-    title?: string,
+type RedifinedFields = "type" | "items" | "additionalItems" | "contains" | "properties" | "patternProperties" | "additionalProperties" | "dependencies" | "propertyNames" | "if" | "then" | "else" | "allOf" | "anyOf" | "oneOf" | "not" | "definitions";
+export type DefinitionOrBoolean = Definition | boolean;
+export interface Definition extends Omit<JSONSchema7, RedifinedFields> {
+    // The type field here is incompatible with the standard definition
     type?: string | string[],
-    definitions?: {[key: string]: any},
-    format?: string,
-    items?: Definition | Definition[],
-    minItems?: number,
-    additionalItems?: {
-        anyOf: Definition[]
-    } | Definition,
-    enum?: PrimitiveType[] | Definition[],
-    default?: PrimitiveType | Object,
-    additionalProperties?: Definition | boolean,
-    required?: string[],
+
+    // Non-standard fields
     propertyOrder?: string[],
-    properties?: {[key: string]: any},
     defaultProperties?: string[],
-    patternProperties?: {[pattern: string]: Definition},
-    typeof?: "function"
+    typeof?: "function",
+
+    // Fields that must be redifined because they make use of this definition itself
+    items?: DefinitionOrBoolean | DefinitionOrBoolean[];
+    additionalItems?: DefinitionOrBoolean;
+    contains?: JSONSchema7;
+    properties?: {
+        [key: string]: DefinitionOrBoolean;
+    };
+    patternProperties?: {
+        [key: string]: DefinitionOrBoolean;
+    };
+    additionalProperties?: DefinitionOrBoolean;
+    dependencies?: {
+        [key: string]: DefinitionOrBoolean | string[];
+    };
+    propertyNames?: DefinitionOrBoolean;
+    if?: DefinitionOrBoolean;
+    then?: DefinitionOrBoolean;
+    else?: DefinitionOrBoolean;
+    allOf?: DefinitionOrBoolean[];
+    anyOf?: DefinitionOrBoolean[];
+    oneOf?: DefinitionOrBoolean[];
+    not?: DefinitionOrBoolean;
+    definitions?: {
+        [key: string]: DefinitionOrBoolean;
+    };
 };
 
 export type SymbolRef = {


### PR DESCRIPTION
…ition

Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [ ] Provide a test case & update the documentation in the `Readme.md`
^ Not sure this is relevant, all the existing tests are passing.

----
Based on discussion in https://github.com/YousefED/typescript-json-schema/issues/310 with @domoritz, i've replaced the existing json schema `Definition` with one based on the `@types/json-schema` `JsonSchema7` definition. Rather than use this type verbatim though, i've extended it to do the following:
- Keep the 3 existing fields which appear to be non-standard `propertyOrder`, `defaultProperties`, and `typeof`.
- Maintain the existing definition of `type`. The issue here is that in addition to the standard types (`'string' | 'number' | 'integer' | 'boolean' | 'object' | 'array' | 'null'`), the value of `undefined` is being used as well. The json-schema doesn't definition doesn't allow for this (as i believe it's mostly equivalent to simply omitting the property from the `required` properties list?), but i've extended the definition in such a way to allow this as is. Might be worth considering properly fixing this issue in the future.
- I also had to redefine all of the nested fields which referenced the `JSONSchema7` definition itself in some way, to correctly use this extended definition throughout.

Ran the test suite and had no issues. I'm not intimately familiar with this project, so apologise if anything has been missed. 
