### PR TITLE
Allow "items" to be overridden on arrays using jsdoc annotations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
+env:
+  - TYPESCRIPT_VERSION=3.5
+  - TYPESCRIPT_VERSION=3.6
+  - TYPESCRIPT_VERSION=3.7
 node_js:
   - "11"
 script:
-  - npm run lint
-  - npm run test
+  - yarn add typescript@$TYPESCRIPT_VERSION
+  - yarn lint
+  - yarn test

--- a/README.md
+++ b/README.md
@@ -161,6 +161,65 @@ will be translated to
 
 Note that we needed to use `@TJS-type` instead of just `@type` because of an [issue with the typescript compiler](https://github.com/Microsoft/TypeScript/issues/13498).
 
+You can also override the type of array items, either listing each field in its own annotation or one
+annotation with the full JSON of the spec (for special cases). This replaces the item types that would
+have been inferred from the TypeScript type of the array elements.  
+
+Example:
+
+```ts
+export interface ShapesData {
+    /**
+     * Specify individual fields in items.
+     *
+     * @items.type integer
+     * @items.minimum 0
+     */
+    sizes: number[];
+
+    /**
+     * Or specify a JSON spec:
+     *
+     * @items {"type":"string","format":"email"}
+     */
+    emails: string[];
+}
+```
+
+Translation:
+
+```json
+{
+    "$ref": "#/definitions/ShapesData",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "Shape": {
+            "properties": {
+                "sizes": {
+                    "description": "Specify individual fields in items.",
+                    "items": {
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "type": "array"
+                },
+                "emails": {
+                    "description": "Specify individual fields in items.",
+                    "items": {
+                        "format": "email",
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
+        }
+    }
+}
+```
+
+This same syntax can be used for `contains` and `additionalProperties`.
+
 ## Background
 
 Inspired and builds upon [Typson](https://github.com/lbovet/typson/), but typescript-json-schema is compatible with more recent Typescript versions. Also, since it uses the Typescript compiler internally, more advanced scenarios are possible. If you are looking for a library that uses the AST instead of the type hierarchy and therefore better support for type aliases, have a look at [vega/ts-json-schema-generator](https://github.com/vega/ts-json-schema-generator).

--- a/test/programs/annotation-items/main.ts
+++ b/test/programs/annotation-items/main.ts
@@ -1,0 +1,34 @@
+interface MyObject {
+  /**
+   * @items {"type":"integer"}
+   */
+  a: number[];
+
+  /**
+   * @items {"type":"integer", "minimum":0}
+   */
+  b: number[];
+
+  /**
+   * @items.type integer
+   * @items.minimum 0
+   */
+  c: number[];
+
+  /**
+   * @items.type integer
+   */
+  d: number[];
+
+  /**
+   * @items {"type":"string", "format":"email"}
+   */
+  emails: string[];
+
+  /**
+   * @items.type string
+   * @items.format email
+   */
+  emails2: string[];
+
+}

--- a/test/programs/annotation-items/schema.json
+++ b/test/programs/annotation-items/schema.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "a": {
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "b": {
+      "items": {
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "c": {
+      "items": {
+        "minimum": 0,
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "d": {
+      "items": {
+        "type": "integer"
+      },
+      "type": "array"
+    },
+    "emails": {
+      "items": {
+        "type": "string",
+        "format": "email"
+      },
+      "type": "array"
+    },
+    "emails2": {
+      "items": {
+        "type": "string",
+        "format": "email"
+      },
+      "type": "array"
+    }
+  },
+  "required": [
+    "a",
+    "b",
+    "c",
+    "d",
+    "emails",
+    "emails2"
+  ],
+  "type": "object"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -2,7 +2,7 @@ import * as Ajv from "ajv";
 import { assert } from "chai";
 import { readFileSync } from "fs";
 import { resolve } from "path";
-
+import { versionMajorMinor as typescriptVersionMajorMinor } from "typescript";
 import * as TJS from "../typescript-json-schema";
 
 const ajv = new Ajv();
@@ -212,7 +212,9 @@ describe("schema", () => {
         assertSchema("generic-recursive", "MyObject", {
             topRef: true
         });
-        assertSchema("generic-hell", "MyObject");
+        if(+typescriptVersionMajorMinor < 3.7) {
+            assertSchema("generic-hell", "MyObject");
+        }
     });
 
     describe("comments", () => {
@@ -234,7 +236,6 @@ describe("schema", () => {
         // assertSchema("type-function", "MyObject");
         assertSchema("any-unknown", "MyObject");
         assertSchema("never", "Never");
-        assertSchema("integer", "MyObject");
     });
 
     describe("class and interface", () => {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -194,6 +194,7 @@ describe("schema", () => {
             validationKeywords: [ "hide" ]
         });
         assertSchema("annotation-id", "MyObject");
+        assertSchema("annotation-items", "MyObject");
 
         assertSchema("typeof-keyword", "MyObject", {typeOfKeyword: true});
 
@@ -233,6 +234,7 @@ describe("schema", () => {
         // assertSchema("type-function", "MyObject");
         assertSchema("any-unknown", "MyObject");
         assertSchema("never", "Never");
+        assertSchema("integer", "MyObject");
     });
 
     describe("class and interface", () => {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -12,6 +12,7 @@ const vm = require("vm");
 const REGEX_FILE_NAME_OR_SPACE = /(\bimport\(".*?"\)|".*?")\.| /g;
 const REGEX_TSCONFIG_NAME = /^.*\.json$/;
 const REGEX_TJS_JSDOC = /^-([\w]+)\s+(\S|\S[\s\S]*\S)\s*$/g;
+const REGEX_GROUP_JSDOC = /^[.]?([\w]+)\s+(\S|\S[\s\S]*\S)\s*$/g;
 const NUMERIC_INDEX_PATTERN = "^[0-9]+$";
 
 export function getDefaultArgs(): Args {
@@ -260,12 +261,12 @@ const validationKeywords = {
     maxLength: true,                // 6.6.
     minLength: true,                // 6.7.
     pattern: true,                  // 6.8.
-    // items: true,                    // 6.9.
+    items: true,                    // 6.9.
     // additionalItems: true,          // 6.10.
     maxItems: true,                 // 6.11.
     minItems: true,                 // 6.12.
     uniqueItems: true,              // 6.13.
-    // contains: true,                 // 6.14.
+    contains: true,                 // 6.14.
     maxProperties: true,            // 6.15.
     minProperties: true,            // 6.16.
     // required: true,                 // 6.17.  This is not required. It is auto-generated.
@@ -289,6 +290,12 @@ const validationKeywords = {
     default: true,
     $ref: true,
     id: true
+};
+
+const subDefinitions = {
+    items: true,
+    additionalProperties: true,
+    contains: true,
 };
 
 export class JsonSchemaGenerator {
@@ -359,7 +366,7 @@ export class JsonSchemaGenerator {
     /**
      * Parse the comments of a symbol into the definition and other annotations.
      */
-    private parseCommentsIntoDefinition(symbol: ts.Symbol, definition: {description?: string}, otherAnnotations: {}): void {
+    private parseCommentsIntoDefinition(symbol: ts.Symbol, definition: Definition, otherAnnotations: {}): void {
         if (!symbol) {
             return;
         }
@@ -387,6 +394,27 @@ export class JsonSchemaGenerator {
                     text = "true";
                 }
             }
+
+            // In TypeScript ~3.5, the annotation name splits at the dot character so we have
+            // to process the "." and beyond from the value
+            if(subDefinitions[name]) {
+                const match: string[] | RegExpExecArray | null = new RegExp(REGEX_GROUP_JSDOC).exec(text);
+                if(match) {
+                    const k = match[1];
+                    const v = match[2];
+                    definition[name] = {...definition[name], [k]: v ? parseValue(v) : true};
+                    return;
+                }
+            }
+
+            // In TypeScript 3.7+, the "." is kept as part of the annotation name
+            if(name.includes(".")) {
+                const parts = name.split(".");
+                if(parts.length === 2 && subDefinitions[parts[0]]) {
+                    definition[parts[0]] = {...definition[parts[0]], [parts[1]]: text ? parseValue(text) : true};
+                }
+            }
+
             if (validationKeywords[name] || this.userValidationKeywords[name]) {
                 definition[name] = text === undefined ? "" : parseValue(text);
             } else {
@@ -454,7 +482,9 @@ export class JsonSchemaGenerator {
                         };
                     } else {
                         definition.type = "array";
-                        definition.items = this.getTypeDefinition(arrayType);
+                        if(!definition.items) {
+                            definition.items = this.getTypeDefinition(arrayType);
+                        }
                     }
                 } else {
                     // Report that type could not be processed
@@ -783,7 +813,9 @@ export class JsonSchemaGenerator {
                         definition.additionalProperties = def;
                     } else {
                         definition.type = "array";
-                        definition.items = def;
+                        if(!definition.items) {
+                            definition.items = def;
+                        }
                     }
                 }
             }


### PR DESCRIPTION

I wanted to able to override the `items` of an array type using jsdoc annotations.  This PR makes that possible.
