### PR TITLE
Integer array test case

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: node_js
+env:
+  - TYPESCRIPT_VERSION=3.5
+  - TYPESCRIPT_VERSION=3.6
+  - TYPESCRIPT_VERSION=3.7
 node_js:
   - "11"
 script:
-  - npm run lint
-  - npm run test
+  - yarn add typescript@$TYPESCRIPT_VERSION
+  - yarn lint
+  - yarn test

--- a/test/programs/type-primitives/main.ts
+++ b/test/programs/type-primitives/main.ts
@@ -3,6 +3,11 @@
 // Special type, should not appear in the schema
 type integer = number;
 
+/**
+ * @type integer
+ */
+type Int = number;
+
 class MyObject {
 
     boolean1: boolean     = true;
@@ -18,6 +23,7 @@ class MyObject {
     array1: Array<any>    = null;
     array2: Array<number> = null;
     array3: integer[]     = null;
+    array4: Int[]     = null;
 
     object1: any          = null;
     object2: {}           = null;

--- a/test/programs/type-primitives/main.ts
+++ b/test/programs/type-primitives/main.ts
@@ -17,6 +17,7 @@ class MyObject {
 
     array1: Array<any>    = null;
     array2: Array<number> = null;
+    array3: integer[]     = null;
 
     object1: any          = null;
     object2: {}           = null;

--- a/test/programs/type-primitives/schema.json
+++ b/test/programs/type-primitives/schema.json
@@ -14,6 +14,13 @@
             },
             "type": "array"
         },
+        "array3": {
+            "default": null,
+            "items": {
+                "type": "integer"
+            },
+            "type": "array"
+        },
         "boolean1": {
             "default": true,
             "type": "boolean"

--- a/test/programs/type-primitives/schema.json
+++ b/test/programs/type-primitives/schema.json
@@ -21,6 +21,13 @@
             },
             "type": "array"
         },
+        "array4": {
+            "default": null,
+            "items": {
+                "type": "integer"
+            },
+            "type": "array"
+        },
         "boolean1": {
             "default": true,
             "type": "boolean"

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -2,7 +2,7 @@ import * as Ajv from "ajv";
 import { assert } from "chai";
 import { readFileSync } from "fs";
 import { resolve } from "path";
-
+import { versionMajorMinor as typescriptVersionMajorMinor } from "typescript";
 import * as TJS from "../typescript-json-schema";
 
 const ajv = new Ajv();
@@ -211,7 +211,9 @@ describe("schema", () => {
         assertSchema("generic-recursive", "MyObject", {
             topRef: true
         });
-        assertSchema("generic-hell", "MyObject");
+        if(+typescriptVersionMajorMinor < 3.7) {
+            assertSchema("generic-hell", "MyObject");
+        }
     });
 
     describe("comments", () => {


### PR DESCRIPTION

This PR just shows whether or not you can do:

```
type integer = number;

interface MyObject {
  array: integer[];
}
```

and get an array with `items.type` set to `integer`.
