### PR TITLE
[Fixes #331][Fixes #333] Fix two issues with the --uniqueNames options

### DIFF
--- a/test/programs/unique-names-multiple-subdefinitions/main.ts
+++ b/test/programs/unique-names-multiple-subdefinitions/main.ts
@@ -1,0 +1,9 @@
+import "./other";
+
+class SubObject {
+  is: "SubObject_1";
+}
+
+class MyObject {
+  sub: SubObject;
+}

--- a/test/programs/unique-names-multiple-subdefinitions/other.ts
+++ b/test/programs/unique-names-multiple-subdefinitions/other.ts
@@ -1,0 +1,3 @@
+class SubObject {
+  is: "SubObject_2";
+}

--- a/test/programs/unique-names-multiple-subdefinitions/schema.json
+++ b/test/programs/unique-names-multiple-subdefinitions/schema.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "sub": {
+            "$ref": "#/definitions/SubObject.0eb4e9af"
+        }
+    },
+    "type": "object",
+    "required": [
+        "sub"
+    ],
+    "definitions": {
+        "SubObject.0eb4e9af": {
+            "properties": {
+                "is": {
+                    "enum": [
+                        "SubObject_1"
+                    ],
+                    "type": "string"
+                }
+            },
+            "required": [
+                "is"
+            ],
+            "type": "object"
+        }
+    }
+}
+

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -294,6 +294,21 @@ describe("schema", () => {
         assertSchema("namespace-deep-2", "RootNamespace.SubNamespace.HelperA");
     });
 
+    describe("uniqueNames", () => {
+        assertSchemas("unique-names", "MyObject", {
+            uniqueNames: true
+        });
+
+        // It should throw an error if there are two definitions for the top-level ref
+        assertRejection("unique-names", "MyObject", {
+            uniqueNames: true
+        });
+
+        assertSchema("unique-names-multiple-subdefinitions", "MyObject", {
+            uniqueNames: true
+        });
+    });
+
     describe("other", () => {
         assertSchema("array-and-description", "MyObject");
 
@@ -310,10 +325,6 @@ describe("schema", () => {
 
         assertSchema("private-members", "MyObject", {
             excludePrivate: true
-        });
-
-        assertSchemas("unique-names", "MyObject", {
-            uniqueNames: true
         });
 
         assertSchema("builtin-names", "Ext.Foo");

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -990,7 +990,7 @@ export class JsonSchemaGenerator {
                 reffedType!.getFlags() & ts.SymbolFlags.Alias ?
                     this.tc.getAliasedSymbol(reffedType!) :
                     reffedType!
-            ).replace(REGEX_FILE_NAME_OR_SPACE, "")
+            ).replace(REGEX_FILE_NAME_OR_SPACE, "");
             if (this.args.uniqueNames) {
                 const sourceFile = getSourceFile(reffedType!);
                 const relativePath = path.relative(process.cwd(), sourceFile.fileName);

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1236,6 +1236,13 @@ export function generateSchema(program: ts.Program, fullTypeName: string, args: 
 
     if (fullTypeName === "*") { // All types in file(s)
         return generator.getSchemaForSymbols(generator.getMainFileSymbols(program, onlyIncludeFiles));
+    } else if (args.uniqueNames) { // Find the hashed type name to use as the root object
+        const matchingSymbols = generator.getSymbols(fullTypeName);
+        if (matchingSymbols.length === 1) {
+            return generator.getSchemaForSymbol(matchingSymbols[0].name);
+        } else {
+            throw new Error(`${matchingSymbols.length} definitions found for requested type "${fullTypeName}".`);
+        }
     } else { // Use specific type as root object
         return generator.getSchemaForSymbol(fullTypeName);
     }

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -248,6 +248,42 @@ function makeNullable(def: Definition) {
 }
 
 /**
+ * Given a Symbol, returns a canonical Definition. That can be either:
+ * 1) The Symbol's valueDeclaration parameter if defined, or
+ * 2) The sole entry in the Symbol's declarations array, provided that array has a length of 1.
+ *
+ * valueDeclaration is listed as a required parameter in the definition of a Symbol, but I've
+ * experienced crashes when it's undefined at runtime, which is the reason for this function's
+ * existence. Not sure if that's a compiler API bug or what.
+ */
+function getCanonicalDeclaration(sym: ts.Symbol): ts.Declaration {
+    if (sym.valueDeclaration !== undefined) {
+        return sym.valueDeclaration;
+    } else if (sym.declarations.length === 1) {
+        return sym.declarations[0];
+    }
+
+    throw new Error(`Symbol "${sym.name}" has no valueDeclaration and ${sym.declarations.length} declarations.`);
+}
+
+/**
+ * Given a Symbol, finds the place it was declared and chases parent pointers until we find a
+ * node where SyntaxKind === SourceFile.
+ */
+function getSourceFile(sym: ts.Symbol): ts.SourceFile {
+    let currentDecl: ts.Node = getCanonicalDeclaration(sym);
+
+    while (currentDecl.kind !== ts.SyntaxKind.SourceFile) {
+        if (currentDecl.parent === undefined) {
+            throw new Error(`Unable to locate source file for declaration "${sym.name}".`);
+        }
+        currentDecl = currentDecl.parent;
+    }
+
+    return currentDecl as ts.SourceFile;
+}
+
+/**
  * JSDoc keywords that should be used to annotate the JSON schema.
  *
  * Many of these validation keywords are defined here: http://json-schema.org/latest/json-schema-validation.html
@@ -950,16 +986,30 @@ export class JsonSchemaGenerator {
 
         let fullTypeName = "";
         if (asTypeAliasRef) {
-            fullTypeName = this.makeTypeNameUnique(
-                typ,
-                this.tc.getFullyQualifiedName(
-                    reffedType!.getFlags() & ts.SymbolFlags.Alias ?
-                        this.tc.getAliasedSymbol(reffedType!) :
-                        reffedType!
-                ).replace(REGEX_FILE_NAME_OR_SPACE, "")
-            );
+            const typeName = this.tc.getFullyQualifiedName(
+                reffedType!.getFlags() & ts.SymbolFlags.Alias ?
+                    this.tc.getAliasedSymbol(reffedType!) :
+                    reffedType!
+            ).replace(REGEX_FILE_NAME_OR_SPACE, "")
+            if (this.args.uniqueNames) {
+                const sourceFile = getSourceFile(reffedType!);
+                const relativePath = path.relative(process.cwd(), sourceFile.fileName);
+                fullTypeName = `${typeName}.${generateHashOfNode(getCanonicalDeclaration(reffedType!), relativePath)}`;
+            } else {
+                fullTypeName = this.makeTypeNameUnique(
+                    typ,
+                    typeName
+                );
+            }
         } else if (asRef) {
-            fullTypeName = this.getTypeName(typ);
+            if (this.args.uniqueNames) {
+                const sym = typ.symbol;
+                const sourceFile = getSourceFile(sym);
+                const relativePath = path.relative(process.cwd(), sourceFile.fileName);
+                fullTypeName = `${this.getTypeName(typ)}.${generateHashOfNode(getCanonicalDeclaration(sym), relativePath)}`;
+            } else {
+                fullTypeName = this.getTypeName(typ);
+            }
         }
 
         if (asRef) {


### PR DESCRIPTION
This PR addresses two issues:
1) The `--uniqueNames` option currently breaks when used with a specified root type, since the input typename is hashed in `buildGenerator()` before we start the generation itself
2) Hashed type names weren't being used for reference properties. Instead, we were handling reference properties the same way we did without `--uniqueNames` and just adding unique definitions on top of that.

Addressing #331 was as simple as looking up types by `typeName` instead of `name` if the `--uniqueNames` flag was enabled. There was already a `generator.getSymbols()` method that I could use to do this.

To fix #333, I added code that finds the source file for a given symbol by chasing `parent` pointers from the symbol's definition. Given that, we can find the relative path and recreate `buildGenerator()`'s logic for hashing type names in other functions.

These are included in a single pull request since I discovered #333 while writing test cases for #331. If you'd rather have them split up, I can do that, but neither was particularly large and they seemed related.