### PR TITLE
Simplify setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ yarn-error.log
 *~
 .#*
 dist/
+*.tgz

--- a/.mocharc.yaml
+++ b/.mocharc.yaml
@@ -1,0 +1,3 @@
+extension: ts
+require: ts-node/register
+timeout: 5000

--- a/package.json
+++ b/package.json
@@ -64,11 +64,10 @@
     "tslint": "^5.20.1"
   },
   "scripts": {
-    "prepublishOnly": "npm run build",
+    "prepack": "tsc",
     "test": "mocha",
     "debug": "ts-node --inspect=19248 --debug-brk typescript-json-schema-cli.ts",
     "run": "ts-node typescript-json-schema-cli.ts",
-    "build": "tsc -p .",
     "lint": "tslint --project tsconfig.json -c tslint.json --exclude '**/*.d.ts'"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "bin": {
     "typescript-json-schema": "./bin/typescript-json-schema"
   },
+  "files": [
+    "bin",
+    "dist"
+  ],
   "author": "Yousef El-Dardiry and Dominik Moritz",
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -60,13 +60,12 @@
     "ajv": "^6.10.2",
     "chai": "^4.2.0",
     "mocha": "^7.0.0",
-    "source-map-support": "^0.5.16",
     "ts-node": "^8.5.4",
     "tslint": "^5.20.1"
   },
   "scripts": {
     "prepublishOnly": "npm run build",
-    "test": "npm run build && mocha -t 5000 --require source-map-support/register dist/test",
+    "test": "mocha",
     "debug": "ts-node --inspect=19248 --debug-brk typescript-json-schema-cli.ts",
     "run": "ts-node typescript-json-schema-cli.ts",
     "build": "tsc -p .",

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "test": "mocha",
     "debug": "ts-node --inspect=19248 --debug-brk typescript-json-schema-cli.ts",
     "run": "ts-node typescript-json-schema-cli.ts",
+    "build": "tsc",
     "lint": "tslint --project tsconfig.json -c tslint.json --exclude '**/*.d.ts'"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,17 +19,11 @@
         "noLib": false,
         "preserveConstEnums": true,
         "sourceMap": true,
-        "watch": false,
-        "typeRoots" : ["node_modules/@types"]
+        "watch": false
     },
-    "include": [
-        "**/*.ts",
-        "node_modules/@types/**/*.d.ts"
-    ],
     "exclude": [
-        "node_modules",
         "example",
-        "test/programs",
+        "test",
         "dist"
     ],
     "compileOnSave": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -829,7 +829,7 @@ set-blocking@^2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
 
-source-map-support@^0.5.16, source-map-support@^0.5.6:
+source-map-support@^0.5.6:
   version "0.5.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.16.tgz#0ae069e7fe3ba7538c64c98515e35339eac5a042"
   integrity sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==


### PR DESCRIPTION
This simplifies the setup around testing and building the project by embracing more standard configurations.

- Mocha is configured using a configuration file, removing the need for CLI options in npm scripts.
- Mocha uses `ts-node/register` instead of `source-map-support/register`. This removes the need to build the project before running tests. This also removes the need for an explicit `source-map-support` dependency.
- The `prepack` script is used for building the project. This makes sure the project is always built before packing or releasing.
- Only relevant files are included in the published package.