### PR TITLE
OpenAPI format generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Options:
   --rejectDateType      Rejects Date fields in type definitions.                     [boolean] [default: false]
   --id                  Set schema id.                                               [string]  [default: ""]
   --defaultNumberType   Default number type.                                         [choices: "number", "integer"] [default: "number"]
+  --openapiFormat       Generate OpenAPI variation of JSON schema format.            [boolean] [default: false]
 ```
 
 ### Programmatic use

--- a/test/programs/openapi-strict/main.ts
+++ b/test/programs/openapi-strict/main.ts
@@ -1,0 +1,15 @@
+type NullableString = string | null;
+
+interface ComposedType {
+    str: string;
+    primitiveUnion: string | number;
+    enumPrimitiveUnion: number | "foo" | "bar";
+    union: { name: string } | string | number;
+
+    nullableStr: string | null;
+    nullablePrimitiveUnion: string | number | null;
+    nullableEnumPrimitiveUnion: number | "foo" | "bar" | null;
+    nullableUnion: { name: string } | string | number | null;
+
+    externallyNullableString: NullableString;
+}

--- a/test/programs/openapi-strict/schema.json
+++ b/test/programs/openapi-strict/schema.json
@@ -1,0 +1,113 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "enumPrimitiveUnion": {
+            "anyOf": [
+                {
+                    "enum": [
+                        "bar",
+                        "foo"
+                    ],
+                    "type": "string"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "externallyNullableString": {
+            "nullable": true,
+            "type": "string"
+        },
+        "nullableEnumPrimitiveUnion": {
+            "anyOf": [
+                {
+                    "enum": [
+                        "bar",
+                        "foo"
+                    ],
+                    "type": "string"
+                },
+                {
+                    "type": "number"
+                }
+            ],
+            "nullable": true
+        },
+        "nullablePrimitiveUnion": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "number"
+                }
+            ],
+            "nullable": true
+        },
+        "nullableStr": {
+            "nullable": true,
+            "type": "string"
+        },
+        "nullableUnion": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                }
+            ],
+            "nullable": true
+        },
+        "primitiveUnion": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "str": {
+            "type": "string"
+        },
+        "union": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "type": "object"
+}
+

--- a/test/programs/openapi/main.ts
+++ b/test/programs/openapi/main.ts
@@ -1,0 +1,28 @@
+type NullableString = string | null;
+
+/** @nullable */
+type AnnotatedString = string;
+
+interface ComposedType {
+    str: string;
+    primitiveUnion: string | number;
+    enumPrimitiveUnion: number | "foo" | "bar";
+    union: { name: string } | string | number;
+
+    nullableStr: string | null;
+    nullablePrimitiveUnion: string | number | null;
+    nullableEnumPrimitiveUnion: number | "foo" | "bar" | null;
+    nullableUnion: { name: string } | string | number | null;
+
+    /** @nullable */
+    annotatedStr: string;
+    /** @nullable */
+    annotatedPrimitiveUnion: string | number;
+    /** @nullable */
+    annotatedEnumPrimitiveUnion: number | "foo" | "bar";
+    /** @nullable */
+    annotatedUnion: { name: string } | string | number;
+
+    externallyAnnotatedString: AnnotatedString;
+    externallyNullableString: NullableString;
+}

--- a/test/programs/openapi/schema.json
+++ b/test/programs/openapi/schema.json
@@ -1,0 +1,165 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "annotatedEnumPrimitiveUnion": {
+            "anyOf": [
+                {
+                    "enum": [
+                        "bar",
+                        "foo"
+                    ],
+                    "type": "string"
+                },
+                {
+                    "type": "number"
+                }
+            ],
+            "nullable": true
+        },
+        "annotatedPrimitiveUnion": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "number"
+                }
+            ],
+            "nullable": true
+        },
+        "annotatedStr": {
+            "nullable": true,
+            "type": "string"
+        },
+        "annotatedUnion": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                }
+            ],
+            "nullable": true
+        },
+        "enumPrimitiveUnion": {
+            "anyOf": [
+                {
+                    "enum": [
+                        "bar",
+                        "foo"
+                    ],
+                    "type": "string"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "externallyAnnotatedString": {
+            "nullable": true,
+            "type": "string"
+        },
+        "externallyNullableString": {
+            "type": "string"
+        },
+        "nullableEnumPrimitiveUnion": {
+            "anyOf": [
+                {
+                    "enum": [
+                        "bar",
+                        "foo"
+                    ],
+                    "type": "string"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "nullablePrimitiveUnion": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "nullableStr": {
+            "type": "string"
+        },
+        "nullableUnion": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                }
+            ]
+        },
+        "primitiveUnion": {
+            "anyOf": [
+                {
+                    "type": "string"
+                },
+                {
+                    "type": "number"
+                }
+            ]
+        },
+        "str": {
+            "type": "string"
+        },
+        "union": {
+            "anyOf": [
+                {
+                    "properties": {
+                        "name": {
+                            "type": "string"
+                        }
+                    },
+                    "type": "object"
+                },
+                {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "number"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "type": "object"
+}
+

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -388,6 +388,20 @@ describe("schema", () => {
         assertSchema("object-numeric-index", "IndexInterface");
         assertSchema("object-numeric-index-as-property", "Target", { required: false });
     });
+
+    describe("openapi", () => {
+        assertSchema("openapi", "ComposedType", { openapiFormat: true, required: false });
+        assertSchema(
+            "openapi-strict",
+            "ComposedType",
+            {
+                openapiFormat: true,
+                strictNullChecks: true,
+                required: false,
+            },
+            { strictNullChecks: true }
+        );
+    });
 });
 
 describe("tsconfig.json", () => {

--- a/typescript-json-schema-cli.ts
+++ b/typescript-json-schema-cli.ts
@@ -71,7 +71,7 @@ export function run() {
         rejectDateType: args.rejectDateType,
         id: args.id,
         defaultNumberType: args.defaultNumberType,
-        openapiFormat: args.openapiNullable,
+        openapiFormat: args.openapiFormat,
     });
 }
 

--- a/typescript-json-schema-cli.ts
+++ b/typescript-json-schema-cli.ts
@@ -47,6 +47,8 @@ export function run() {
         .option("defaultNumberType").choices("defaultNumberType", ["number", "integer"])
             .default("defaultNumberType", defaultArgs.defaultNumberType)
             .describe("defaultNumberType", "Default number type.")
+        .boolean("openapiFormat").default("openapiFormat", defaultArgs.openapiFormat)
+            .describe("openapiFormat", "Generate OpenAPI variation of JSON schema format")
         .argv;
 
     exec(args._[0], args._[1], {
@@ -69,6 +71,7 @@ export function run() {
         rejectDateType: args.rejectDateType,
         id: args.id,
         defaultNumberType: args.defaultNumberType,
+        openapiFormat: args.openapiNullable,
     });
 }
 

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -836,7 +836,7 @@ export class JsonSchemaGenerator {
 
         if (simpleTypes.length > 0) {
             if (this.args.openapiFormat && simpleTypes.length !== 1) {
-                schemas.push({ [unionModifier]: simpleTypes.map(type => ({ type })) })
+                schemas.push({ [unionModifier]: simpleTypes.map((type) => ({ type })) });
             } else {
                 schemas.push({ type: simpleTypes.length === 1 ? simpleTypes[0] : simpleTypes });
             }

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -836,7 +836,7 @@ export class JsonSchemaGenerator {
 
         if (simpleTypes.length > 0) {
             if (this.args.openapiFormat && simpleTypes.length !== 1) {
-                schemas.push({ [unionModifier]: simpleTypes })
+                schemas.push({ [unionModifier]: simpleTypes.map(type => ({ type })) })
             } else {
                 schemas.push({ type: simpleTypes.length === 1 ? simpleTypes[0] : simpleTypes });
             }


### PR DESCRIPTION
[OpenAPI specification data types](https://swagger.io/docs/specification/data-models/data-types/) uses JSON schema to formulate the shape of the data. It is pretty much identical to JSON schema, except it differs from the specification in two ways:

- `null` is not a type in the OpenAPI. Nullability is represented by setting `"nullable": true`
- Type cannot be an array of types, instead `anyOf` or `oneOf` should always be used.

In this PR I've added this compatibility layer behind the `openapiFormat` flag (or `--openapiFormat` in the cli). Added some basic test coverage, and updated README.md a bit.

I've modified this project for my own use to generate (annoying to type otherwise) JSON schema inside of the OpenAPI spec. Yet I've thought bringing this change upstream can be helpful to others.

Since the difference between JSON schema and OpenAPI data type specification is rather small, there is no issue associated and I've just implemented it myself.

_P.S. This is my first OS contribution. Dunno how it should work_