### PR TITLE
Fix AJV warning, "$ref: keywords ignored in schema"

### DIFF
--- a/test/programs/comments-override/schema.json
+++ b/test/programs/comments-override/schema.json
@@ -32,7 +32,6 @@
         },
         "sub2": {
             "$ref": "#/definitions/MySubObject",
-            "additionalProperties": false,
             "description": "Property-level description"
         }
     },

--- a/test/programs/namespace-deep-1/schema.json
+++ b/test/programs/namespace-deep-1/schema.json
@@ -55,7 +55,6 @@
             ],
             "type": "object"
         }
-    },
-    "type": "object"
+    }
 }
 

--- a/test/programs/namespace-deep-2/schema.json
+++ b/test/programs/namespace-deep-2/schema.json
@@ -55,7 +55,6 @@
             ],
             "type": "object"
         }
-    },
-    "type": "object"
+    }
 }
 

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -13,7 +13,7 @@ const ajv = new Ajv({
             ajvWarnings.push(message);
         },
         error: (message) => {
-            throw new Error('AJV error: ' + message);
+            throw new Error("AJV error: " + message);
         },
     },
 });

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -372,7 +372,7 @@ const annotationKeywords: { [k in keyof typeof validationKeywords]?: true } = {
     examples: true,
     // A JSDoc $ref annotation can appear as a $ref.
     $ref: true
-}
+};
 
 const subDefinitions = {
     items: true,

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -360,6 +360,20 @@ const validationKeywords = {
     id: true
 };
 
+/**
+ * Subset of descriptive, non-type keywords that are permitted alongside a $ref.
+ * Prior to JSON Schema draft 2019-09, $ref is a special keyword that doesn't
+ * permit keywords alongside it, and so AJV may raise warnings if it encounters
+ * any type-related keywords; see https://github.com/ajv-validator/ajv/issues/1121
+ */
+const annotationKeywords: { [k in keyof typeof validationKeywords]?: true } = {
+    description: true,
+    default: true,
+    examples: true,
+    // A JSDoc $ref annotation can appear as a $ref.
+    $ref: true
+}
+
 const subDefinitions = {
     items: true,
     additionalProperties: true,
@@ -1262,10 +1276,8 @@ export class JsonSchemaGenerator {
             this.recursiveTypeRef.delete(fullTypeName);
             // If the type was recursive (there is reffedDefinitions) - lets replace it to reference
             if (this.reffedDefinitions[fullTypeName]) {
-                // Here we may want to filter out all type specific fields
-                // and include fields like description etc
                 const annotations = Object.entries(returnedDefinition).reduce((acc, [key, value]) => {
-                    if (validationKeywords[key] && typeof value !== undefined) {
+                    if (annotationKeywords[key] && typeof value !== undefined) {
                         acc[key] = value;
                     }
                     return acc;


### PR DESCRIPTION
The improved handling for recursive schemas that was added in #383 resulted in type-related keywords being added alongside the `$ref` keywords. Such keywords are ignored according to draft-07 of the JSON Schema, so AJV (and possibly other tools) warn about them.

For more information, see https://github.com/ajv-validator/ajv/issues/1121

To address this, I revised the recursive ref logic to only include "annotation" keywords, based on the list here:

http://json-schema.org/understanding-json-schema/reference/generic.html#annotations

(That page also includes `title`, but typescript-json-schema currently doesn't recognize that.)

Note that draft 2019-09 of JSON Schema changes `$ref` to act like a normal keyword, so this change will no longer be necessary in that version of the spec.

Fixes #391.

Please:
- [ ] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [ ] Provide a test case & update the documentation in the `Readme.md`
