### PR TITLE
fix: top-level alias type comments parse

### DIFF
--- a/test/programs/type-aliases-partial/schema.json
+++ b/test/programs/type-aliases-partial/schema.json
@@ -15,6 +15,7 @@
   "definitions": {
     "__type": {
       "type": "object",
+      "description": "Make all properties in T optional",
       "properties": {
         "x": {
           "type": "number"
@@ -29,6 +30,7 @@
     },
     "__type_1": {
       "type": "object",
+      "description": "Make all properties in T optional",
       "properties": {
         "a": {
           "type": "number"

--- a/test/programs/type-recursive/schema.json
+++ b/test/programs/type-recursive/schema.json
@@ -22,7 +22,9 @@
           },
           "type": "array"
         }
-      ]
+      ],
+      "description": "A recursive type"
     }
-  }
+  },
+  "description": "A recursive type"
 }

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1197,6 +1197,7 @@ export class JsonSchemaGenerator {
         const otherAnnotations = {};
         this.parseCommentsIntoDefinition(reffedType!, definition, otherAnnotations); // handle comments in the type alias declaration
         this.parseCommentsIntoDefinition(symbol!, definition, otherAnnotations);
+        this.parseCommentsIntoDefinition(typ.aliasSymbol!, definition, otherAnnotations);
         if (prop) {
             this.parseCommentsIntoDefinition(prop, returnedDefinition, otherAnnotations);
         }


### PR DESCRIPTION
Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [ ] Provide a test case & update the documentation in the `Readme.md`

As discussed in #394 , parse comment for top-level type.