### PR TITLE
Fix tuple handling (maxItems vs. additionalItems)

### DIFF
--- a/test/programs/type-aliases-fixed-size-array/schema.json
+++ b/test/programs/type-aliases-fixed-size-array/schema.json
@@ -1,15 +1,5 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "additionalItems": {
-        "anyOf": [
-            {
-                "type": "string"
-            },
-            {
-                "type": "number"
-            }
-        ]
-    },
     "items": [
         {
             "type": "string"
@@ -18,6 +8,7 @@
             "type": "number"
         }
     ],
+    "maxItems": 2,
     "minItems": 2,
     "type": "array"
 }

--- a/test/programs/type-aliases-tuple-of-variable-length/schema.json
+++ b/test/programs/type-aliases-tuple-of-variable-length/schema.json
@@ -12,18 +12,6 @@
             "type": "boolean"
         }
     ],
-    "additionalItems": {
-        "anyOf": [
-            {
-                "type": "string"
-            },
-            {
-                "type": "number"
-            },
-            {
-                "type": "boolean"
-            }
-        ]
-    },
+    "maxItems": 3,
     "minItems": 2
 }

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -201,7 +201,7 @@ describe("schema", () => {
             aliasRef: true,
             topRef: false,
         });
-        // disabled beacuse of #80
+        // disabled because of #80
         // assertSchema("type-aliases-alias-ref-topref", "MyAlias", {
         //     useTypeAliasRef: true,
         //     useRootRef: true
@@ -210,7 +210,7 @@ describe("schema", () => {
             aliasRef: true,
             topRef: true,
         });
-        // disabled beacuse of #80
+        // disabled because of #80
         // assertSchema("type-aliases-recursive-alias-topref", "MyAlias", {
         //     useTypeAliasRef: true,
         //     useRootRef: true

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -96,7 +96,7 @@ export interface Definition extends Omit<JSONSchema7, RedefinedFields> {
     defaultProperties?: string[];
     typeof?: "function";
 
-    // Fields that must be redifined because they make use of this definition itself
+    // Fields that must be redefined because they make use of this definition itself
     items?: DefinitionOrBoolean | DefinitionOrBoolean[];
     additionalItems?: DefinitionOrBoolean;
     contains?: JSONSchema7;
@@ -720,7 +720,7 @@ export class JsonSchemaGenerator {
                         // node
                         const exp = (<any>initial).expression;
                         const text = (<any>exp).text;
-                        // if it is an expression with a text literal, chances are it is the enum convension:
+                        // if it is an expression with a text literal, chances are it is the enum convention:
                         // CASELABEL = 'literal' as any
                         if (text) {
                             enumValues.push(text);
@@ -1427,7 +1427,7 @@ export function buildGenerator(
         }
         return onlyIncludeFiles.indexOf(file.fileName) >= 0;
     }
-    // Use defaults unles otherwise specified
+    // Use defaults unless otherwise specified
     const settings = getDefaultArgs();
 
     for (const pref in args) {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -547,9 +547,7 @@ export class JsonSchemaGenerator {
                 definition.additionalItems = fixedTypes[fixedTypes.length - 1];
                 fixedTypes.splice(fixedTypes.length - 1, 1);
             } else {
-                definition.additionalItems = {
-                    anyOf: fixedTypes,
-                };
+                definition.maxItems = targetTupleType.fixedLength;
             }
         } else {
             const propertyTypeString = this.tc.typeToString(


### PR DESCRIPTION
If I understand correctly, typescript-json-schema's use of additionalItems was incorrect; it had the result of allowing any number of additional items to be added to the end of the tuple, instead of restricting the tuple to only the listed items. It was also causing warnings in AJV 7's new strict mode:
    
> strict mode: "items" is 2-tuple, but minItems or maxItems/additionalItems are not specified or different
    
For more information:
    
- https://github.com/ajv-validator/ajv/blob/v7.0.0/docs/strict-mode.md#prohibit-unconstrained-tuples
- https://json-schema.org/understanding-json-schema/reference/array.html#tuple-validation
    
Fixes #393.