### PR TITLE
Add require functionality in annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,72 @@ interface MyObject {
 
 Note: this feature doesn't work for generic types & array types, it mainly works in very simple cases.
 
+### `require` a variable from a file
+
+When you want to import for example an object or an array into your property defined in annotation, you can use `require`.
+
+Example:
+
+```ts
+export interface InnerData {
+  age: number;
+  name: string;
+  free: boolean;
+}
+
+export interface UserData {
+  /**
+   * Specify required object
+   * 
+   * @examples require("./example.ts").example
+   */
+  data: InnerData;
+}
+```
+
+file `example.ts`
+
+```ts
+export const example: InnerData[] = [{
+  age: 30,
+  name: "Ben",
+  free: false
+}]
+```
+
+Translation:
+
+```json
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "data": {
+      "description": "Specify required object",
+      "examples": [
+        { 
+          "age": 30, 
+          "name": "Ben", 
+          "free": false 
+        }
+      ],
+      "type": "object",
+      "properties": {
+        "age": { "type": "number" },
+        "name": { "type": "string" },
+        "free": { "type": "boolean" }
+      },
+      "required": ["age", "free", "name"]
+    }
+  },
+  "required": ["data"],
+  "type": "object"
+}
+```
+
+Also you can use `require(".").example`, which will try to find exported variable with name 'example' in current file. Or you can use `require("./someFile.ts")`, which will try to use default exported variable from 'someFile.ts'.
+
+Note: For `examples` a required variable must be an array.
+
 ## Background
 
 Inspired and builds upon [Typson](https://github.com/lbovet/typson/), but typescript-json-schema is compatible with more recent Typescript versions. Also, since it uses the Typescript compiler internally, more advanced scenarios are possible. If you are looking for a library that uses the AST instead of the type hierarchy and therefore better support for type aliases, have a look at [vega/ts-json-schema-generator](https://github.com/vega/ts-json-schema-generator).

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Options:
   --rejectDateType      Rejects Date fields in type definitions.                     [boolean] [default: false]
   --id                  Set schema id.                                               [string]  [default: ""]
   --defaultNumberType   Default number type.                                         [choices: "number", "integer"] [default: "number"]
+  --tsNodeRegister      Use ts-node/register (needed for require typescript files).  [boolean] [default: false]
 ```
 
 ### Programmatic use
@@ -59,12 +60,12 @@ import * as TJS from "typescript-json-schema";
 
 // optionally pass argument to schema generator
 const settings: TJS.PartialArgs = {
-  required: true,
+    required: true,
 };
 
 // optionally pass ts compiler options
 const compilerOptions: TJS.CompilerOptions = {
-  strictNullChecks: true,
+    strictNullChecks: true,
 };
 
 // optionally pass a base path
@@ -95,7 +96,7 @@ generator.getSchemaForSymbol("AnotherType");
 // In larger projects type names may not be unique,
 // while unique names may be enabled.
 const settings: TJS.PartialArgs = {
-  uniqueNames: true,
+    uniqueNames: true,
 };
 
 const generator = TJS.buildGenerator(program, settings);
@@ -114,10 +115,10 @@ const fullSymbolList = generator.getSymbols();
 
 ```ts
 type SymbolRef = {
-  name: string;
-  typeName: string;
-  fullyQualifiedName: string;
-  symbol: ts.Symbol;
+    name: string;
+    typeName: string;
+    fullyQualifiedName: string;
+    symbol: ts.Symbol;
 };
 ```
 
@@ -131,13 +132,13 @@ For example
 
 ```ts
 export interface Shape {
-  /**
-   * The size of the shape.
-   *
-   * @minimum 0
-   * @TJS-type integer
-   */
-  size: number;
+    /**
+     * The size of the shape.
+     *
+     * @minimum 0
+     * @TJS-type integer
+     */
+    size: number;
 }
 ```
 
@@ -145,20 +146,20 @@ will be translated to
 
 ```json
 {
-  "$ref": "#/definitions/Shape",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "definitions": {
-    "Shape": {
-      "properties": {
-        "size": {
-          "description": "The size of the shape.",
-          "minimum": 0,
-          "type": "integer"
+    "$ref": "#/definitions/Shape",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "Shape": {
+            "properties": {
+                "size": {
+                    "description": "The size of the shape.",
+                    "minimum": 0,
+                    "type": "integer"
+                }
+            },
+            "type": "object"
         }
-      },
-      "type": "object"
     }
-  }
 }
 ```
 
@@ -172,20 +173,20 @@ Example:
 
 ```ts
 export interface ShapesData {
-  /**
-   * Specify individual fields in items.
-   *
-   * @items.type integer
-   * @items.minimum 0
-   */
-  sizes: number[];
+    /**
+     * Specify individual fields in items.
+     *
+     * @items.type integer
+     * @items.minimum 0
+     */
+    sizes: number[];
 
-  /**
-   * Or specify a JSON spec:
-   *
-   * @items {"type":"string","format":"email"}
-   */
-  emails: string[];
+    /**
+     * Or specify a JSON spec:
+     *
+     * @items {"type":"string","format":"email"}
+     */
+    emails: string[];
 }
 ```
 
@@ -193,31 +194,31 @@ Translation:
 
 ```json
 {
-  "$ref": "#/definitions/ShapesData",
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "definitions": {
-    "Shape": {
-      "properties": {
-        "sizes": {
-          "description": "Specify individual fields in items.",
-          "items": {
-            "minimum": 0,
-            "type": "integer"
-          },
-          "type": "array"
-        },
-        "emails": {
-          "description": "Or specify a JSON spec:",
-          "items": {
-            "format": "email",
-            "type": "string"
-          },
-          "type": "array"
+    "$ref": "#/definitions/ShapesData",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "Shape": {
+            "properties": {
+                "sizes": {
+                    "description": "Specify individual fields in items.",
+                    "items": {
+                        "minimum": 0,
+                        "type": "integer"
+                    },
+                    "type": "array"
+                },
+                "emails": {
+                    "description": "Or specify a JSON spec:",
+                    "items": {
+                        "format": "email",
+                        "type": "string"
+                    },
+                    "type": "array"
+                }
+            },
+            "type": "object"
         }
-      },
-      "type": "object"
     }
-  }
 }
 ```
 
@@ -232,7 +233,7 @@ Example:
 ```typescript
 type integer = number;
 interface MyObject {
-  n: integer;
+    n: integer;
 }
 ```
 
@@ -240,24 +241,26 @@ Note: this feature doesn't work for generic types & array types, it mainly works
 
 ### `require` a variable from a file
 
+(for requiring typescript files is needed to set argument `tsNodeRegister` to true)
+
 When you want to import for example an object or an array into your property defined in annotation, you can use `require`.
 
 Example:
 
 ```ts
 export interface InnerData {
-  age: number;
-  name: string;
-  free: boolean;
+    age: number;
+    name: string;
+    free: boolean;
 }
 
 export interface UserData {
-  /**
-   * Specify required object
-   * 
-   * @examples require("./example.ts").example
-   */
-  data: InnerData;
+    /**
+     * Specify required object
+     *
+     * @examples require("./example.ts").example
+     */
+    data: InnerData;
 }
 ```
 
@@ -275,28 +278,28 @@ Translation:
 
 ```json
 {
-  "$schema": "http://json-schema.org/draft-07/schema#",
-  "properties": {
-    "data": {
-      "description": "Specify required object",
-      "examples": [
-        { 
-          "age": 30, 
-          "name": "Ben", 
-          "free": false 
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "data": {
+            "description": "Specify required object",
+            "examples": [
+                {
+                    "age": 30,
+                    "name": "Ben",
+                    "free": false
+                }
+            ],
+            "type": "object",
+            "properties": {
+                "age": { "type": "number" },
+                "name": { "type": "string" },
+                "free": { "type": "boolean" }
+            },
+            "required": ["age", "free", "name"]
         }
-      ],
-      "type": "object",
-      "properties": {
-        "age": { "type": "number" },
-        "name": { "type": "string" },
-        "free": { "type": "boolean" }
-      },
-      "required": ["age", "free", "name"]
-    }
-  },
-  "required": ["data"],
-  "type": "object"
+    },
+    "required": ["data"],
+    "type": "object"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json-schema",
-  "version": "0.48.0",
+  "version": "0.47.0",
   "description": "typescript-json-schema generates JSON Schema files from your Typescript sources",
   "main": "dist/typescript-json-schema.js",
   "typings": "dist/typescript-json-schema.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-json-schema",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "typescript-json-schema generates JSON Schema files from your Typescript sources",
   "main": "dist/typescript-json-schema.js",
   "typings": "dist/typescript-json-schema.d.ts",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/json-schema": "^7.0.6",
     "glob": "^7.1.6",
     "json-stable-stringify": "^1.0.1",
+    "ts-node": "^9.1.1",
     "typescript": "^4.1.3",
     "yargs": "^16.2.0"
   },
@@ -62,7 +63,6 @@
     "mocha": "^8.2.1",
     "prettier": "^2.2.1",
     "source-map-support": "^0.5.19",
-    "ts-node": "^9.1.1",
     "tslint": "^6.1.3"
   },
   "scripts": {

--- a/test/programs/annotation-required/examples.ts
+++ b/test/programs/annotation-required/examples.ts
@@ -1,0 +1,15 @@
+import { MyDefaultObject, MySubObject2 } from "./main";
+
+export const mySubObject2Example: MySubObject2[] = [{
+    bool: true,
+    string: "string",
+    object: { prop: 1 }
+}];
+
+const myDefaultExample: MyDefaultObject[] = [{
+    age: 30,
+    name: "me",
+    free: true
+}]
+
+export default myDefaultExample;

--- a/test/programs/annotation-required/main.ts
+++ b/test/programs/annotation-required/main.ts
@@ -1,0 +1,40 @@
+interface MySubObject {
+    bool: boolean;
+    string: string;
+    object: object | null;
+    /**
+     * @examples require('./examples.ts').mySubObject2Example
+     */
+    subObject?: MySubObject2;
+}
+
+export interface MySubObject2 {
+    bool: boolean;
+    string: string;
+    object: object;
+}
+
+export interface MyDefaultObject {
+  age: number;
+  name: string;
+  free?: boolean;
+}
+
+export interface MyObject {
+    /**
+     * @examples require(".").innerExample
+     */
+    filled: MySubObject;
+    /**
+     * @examples require('./examples.ts')
+     */
+    defaultObject: MyDefaultObject;
+}
+
+export const innerExample: MySubObject[] = [
+    {
+        bool: true,
+        string: "string",
+        object: {}
+    },
+];

--- a/test/programs/annotation-required/schema.json
+++ b/test/programs/annotation-required/schema.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyDefaultObject": {
+      "properties": {
+        "age": {
+          "type": "number"
+        },
+        "free": {
+          "type": "boolean"
+        },
+        "name": {
+          "type": "string"
+        }
+      },
+      "required": ["age", "name"],
+      "type": "object"
+    },
+    "MySubObject": {
+      "properties": {
+        "bool": {
+          "type": "boolean"
+        },
+        "object": {
+          "additionalProperties": true,
+          "properties": {},
+          "type": "object"
+        },
+        "string": {
+          "type": "string"
+        },
+        "subObject": {
+          "$ref": "#/definitions/MySubObject2",
+          "examples": [
+            {
+              "bool": true,
+              "object": {
+                "prop": 1
+              },
+              "string": "string"
+            }
+          ]
+        }
+      },
+      "required": ["bool", "object", "string"],
+      "type": "object"
+    },
+    "MySubObject2": {
+      "properties": {
+        "bool": {
+          "type": "boolean"
+        },
+        "object": {
+          "additionalProperties": true,
+          "properties": {},
+          "type": "object"
+        },
+        "string": {
+          "type": "string"
+        }
+      },
+      "required": ["bool", "object", "string"],
+      "type": "object"
+    }
+  },
+  "properties": {
+    "defaultObject": {
+      "$ref": "#/definitions/MyDefaultObject",
+      "examples": [
+        {
+          "age": 30,
+          "free": true,
+          "name": "me"
+        }
+      ]
+    },
+    "filled": {
+      "$ref": "#/definitions/MySubObject",
+      "examples": [
+        {
+          "bool": true,
+          "object": {},
+          "string": "string"
+        }
+      ]
+    }
+  },
+  "required": ["defaultObject", "filled"],
+  "type": "object"
+}

--- a/test/require.test.ts
+++ b/test/require.test.ts
@@ -1,0 +1,120 @@
+import { assert } from "chai";
+import { regexRequire } from "../typescript-json-schema";
+
+const basicFilePath = "./file.ts";
+const paths = [
+    basicFilePath,
+    ".",
+    "@some-module",
+    "@some-module/my_123",
+    "/some/absolute/path-to-file",
+    "../relative-path",
+    "../../../relative-path/to-file.ts",
+    "./relative-path/myFile123.js",
+];
+
+const objName = "objectName";
+const extendedObjName = "$object12_Name";
+
+const getValues = (singleQuotation: boolean) => {
+    const quot = singleQuotation ? "'" : '"';
+    return {
+        path: `${quot}${basicFilePath}${quot}`,
+        quot,
+        quotName: singleQuotation ? "single" : "double",
+    };
+};
+
+const matchSimple = (
+    match: RegExpExecArray | null,
+    singleQuotation: boolean,
+    filePath: string,
+    propertyName?: string
+) => {
+    assert.isArray(match);
+    const quotation = singleQuotation ? "'" : '"';
+    const expectedFileName = `${quotation}${filePath}${quotation}`;
+    assert(match![2] === expectedFileName, `File doesn't match, got: ${match![2]}, expected: ${expectedFileName}`);
+    assert(match![4] === propertyName, `Poperty has to be ${propertyName?.toString()}`);
+};
+
+const commonTests = (singleQuotation: boolean) => {
+    const { quotName, path } = getValues(singleQuotation);
+    it(`will not match, (${quotName} quotation mark)`, () => {
+        assert.isNull(regexRequire(`pre require(${path})`));
+        assert.isNull(regexRequire(`  e require(${path})`));
+        assert.isNull(regexRequire(`require(${path})post`));
+        assert.isNull(regexRequire(`requir(${path})`));
+        assert.isNull(regexRequire(`require(${path}).e-r`));
+        assert.isNull(regexRequire(`require(${path}`));
+        assert.isNull(regexRequire(`require${path})`));
+        assert.isNull(regexRequire(`require[${path}]`));
+        assert.isNull(regexRequire(`REQUIRE[${path}]`));
+    });
+};
+
+const tests = (singleQuotation: boolean, objectName?: string) => {
+    const { quotName, path, quot } = getValues(singleQuotation);
+    const objNamePath = objectName ? `.${objectName}` : "";
+    it(`basic path (${quotName} quotation mark)`, () => {
+        matchSimple(regexRequire(`require(${path})${objNamePath}`), singleQuotation, basicFilePath, objectName);
+    });
+    it(`white spaces and basic path (${quotName} quotation mark)`, () => {
+        matchSimple(regexRequire(`   require(${path})${objNamePath}`), singleQuotation, basicFilePath, objectName);
+        matchSimple(regexRequire(`require(${path})${objNamePath}    `), singleQuotation, basicFilePath, objectName);
+        matchSimple(
+            regexRequire(`      require(${path})${objNamePath}    `),
+            singleQuotation,
+            basicFilePath,
+            objectName
+        );
+        matchSimple(
+            regexRequire(`      require(${path})${objNamePath}    comment`),
+            singleQuotation,
+            basicFilePath,
+            objectName
+        );
+        matchSimple(
+            regexRequire(`      require(${path})${objNamePath}    comment   `),
+            singleQuotation,
+            basicFilePath,
+            objectName
+        );
+    });
+    it(`paths (${quotName} quotation mark)`, () => {
+        paths.forEach((pathName) => {
+            matchSimple(
+                regexRequire(`require(${quot}${pathName}${quot})${objNamePath}`),
+                singleQuotation,
+                pathName,
+                objectName
+            );
+        });
+    });
+};
+
+describe("Double quotation", () => {
+    tests(false);
+    commonTests(false);
+});
+
+describe("Single quotation", () => {
+    tests(true);
+    commonTests(true);
+});
+
+describe("Double quotation + object", () => {
+    tests(false, objName);
+});
+
+describe("Single quotation + object", () => {
+    tests(true, objName);
+});
+
+describe("Double quotation + extended object name", () => {
+    tests(false, extendedObjName);
+});
+
+describe("Single quotation + extended object name", () => {
+    tests(true, extendedObjName);
+});

--- a/test/require.test.ts
+++ b/test/require.test.ts
@@ -93,28 +93,13 @@ const tests = (singleQuotation: boolean, objectName?: string) => {
     });
 };
 
-describe("Double quotation", () => {
+describe("Require regex pattern", () => {
     tests(false);
     commonTests(false);
-});
-
-describe("Single quotation", () => {
     tests(true);
     commonTests(true);
-});
-
-describe("Double quotation + object", () => {
     tests(false, objName);
-});
-
-describe("Single quotation + object", () => {
     tests(true, objName);
-});
-
-describe("Double quotation + extended object name", () => {
     tests(false, extendedObjName);
-});
-
-describe("Single quotation + extended object name", () => {
     tests(true, extendedObjName);
 });

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -274,8 +274,6 @@ describe("schema", () => {
         });
         assertSchema("annotation-items", "MyObject");
 
-        assertSchema("annotation-required", "MyObject");
-
         assertSchema("typeof-keyword", "MyObject", { typeOfKeyword: true });
 
         assertSchema("user-validation-keywords", "MyObject", {
@@ -459,4 +457,10 @@ describe("tsconfig.json", () => {
             assert.throws(() => generator.getSchemaForSymbol("IncludedOnlyByTsConfig"));
         }
     });
+});
+
+describe("Required", () => {
+    // this part is needed to resolve ts script internaly
+    require("ts-node/register");
+    assertSchema("annotation-required", "MyObject");
 });

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -274,6 +274,8 @@ describe("schema", () => {
         });
         assertSchema("annotation-items", "MyObject");
 
+        assertSchema("annotation-required", "MyObject");
+
         assertSchema("typeof-keyword", "MyObject", { typeOfKeyword: true });
 
         assertSchema("user-validation-keywords", "MyObject", {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -459,8 +459,8 @@ describe("tsconfig.json", () => {
     });
 });
 
-describe("Required", () => {
-    // this part is needed to resolve ts script internaly
-    require("ts-node/register");
-    assertSchema("annotation-required", "MyObject");
+describe("Functionality 'required' in annotation", () => {
+    assertSchema("annotation-required", "MyObject", {
+        tsNodeRegister: true
+    });
 });

--- a/typescript-json-schema-cli.ts
+++ b/typescript-json-schema-cli.ts
@@ -22,8 +22,8 @@ export function run() {
             .describe("noExtraProps", "Disable additional properties in objects by default.")
         .boolean("propOrder").default("propOrder", defaultArgs.propOrder)
             .describe("propOrder", "Create property order definitions.")
-        .boolean("typeOfKeyword").default("typeOfKeyword", defaultArgs.typeOfKeyword)
-            .describe("typeOfKeyword", "Use typeOf keyword (https://goo.gl/DC6sni) for functions.")
+        .boolean("useTypeOfKeyword").default("useTypeOfKeyword", defaultArgs.typeOfKeyword)
+            .describe("useTypeOfKeyword", "Use typeOf keyword (https://goo.gl/DC6sni) for functions.")
         .boolean("required").default("required", defaultArgs.required)
             .describe("required", "Create required array for non-optional properties.")
         .boolean("strictNullChecks").default("strictNullChecks", defaultArgs.strictNullChecks)
@@ -47,6 +47,8 @@ export function run() {
         .option("defaultNumberType").choices("defaultNumberType", ["number", "integer"])
             .default("defaultNumberType", defaultArgs.defaultNumberType)
             .describe("defaultNumberType", "Default number type.")
+        .boolean("tsNodeRegister").default("tsNodeRegister", defaultArgs.tsNodeRegister)
+            .describe("tsNodeRegister", "Use ts-node/register (needed for requiring typescript files).")
         .argv;
 
     exec(args._[0], args._[1], {
@@ -69,6 +71,7 @@ export function run() {
         rejectDateType: args.rejectDateType,
         id: args.id,
         defaultNumberType: args.defaultNumberType,
+        tsNodeRegister: args.tsNodeRegister,
     });
 }
 

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -185,8 +185,14 @@ function resolveRequiredFile(symbol: ts.Symbol, key: string, fileName: string, o
         throw Error("File couldn't be loaded");
     }
     var requiredObject = objectName ? requiredFile[objectName] : requiredFile.default;
+    if (requiredObject === undefined) {
+        throw Error("Required variable is undefined");
+    }
+    if (typeof requiredObject === "function") {
+        throw Error("Can't use function as a variable");
+    }
     if (key === "examples" && !Array.isArray(requiredObject)) {
-        throw Error("Required object isn't an array");
+        throw Error("Required variable isn't an array");
     }
     return requiredObject;
 }

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -176,7 +176,7 @@ function unique(arr: string[]): string[] {
  */
 function resolveRequiredFile(symbol: ts.Symbol, key: string, fileName: string, objectName: string): any {
     const sourceFile = getSourceFile(symbol);
-    const requiredFilePath = /[.\/]+/.test(fileName)
+    const requiredFilePath = /^[.\/]+/.test(fileName)
         ? fileName === "."
             ? path.resolve(sourceFile.fileName)
             : path.resolve(path.dirname(sourceFile.fileName), fileName)
@@ -204,7 +204,7 @@ function resolveRequiredFile(symbol: ts.Symbol, key: string, fileName: string, o
 function parseValue(symbol: ts.Symbol, key: string, value: string): any {
     const match = REGEX_REQUIRE.exec(value);
     if (match) {
-        const fileName = match[2].substr(1, match[2].length - 2);
+        const fileName = match[2].substr(1, match[2].length - 2).trim();
         const objectName = match[4];
         return resolveRequiredFile(symbol, key, fileName, objectName);
     }

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -13,7 +13,7 @@ const REGEX_FILE_NAME_OR_SPACE = /(\bimport\(".*?"\)|".*?")\.| /g;
 const REGEX_TSCONFIG_NAME = /^.*\.json$/;
 const REGEX_TJS_JSDOC = /^-([\w]+)\s+(\S|\S[\s\S]*\S)\s*$/g;
 const REGEX_GROUP_JSDOC = /^[.]?([\w]+)\s+(\S|\S[\s\S]*\S)\s*$/g;
-const REGEX_REQUIRE = /^(\s+)?require\((\'[a-zA-Z0-9.\/_-]+\'|\"[a-zA-Z0-9.\/_-]+\")\)(\.([a-zA-Z0-9_-]+))?(\s+)?/;
+const REGEX_REQUIRE = /^(\s+)?require\((\'@?[a-zA-Z0-9.\/_-]+\'|\"@?[a-zA-Z0-9.\/_-]+\")\)(\.([a-zA-Z0-9_$]+))?(\s+|$)/;
 const NUMERIC_INDEX_PATTERN = "^[0-9]+$";
 
 export function getDefaultArgs(): Args {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -55,6 +55,7 @@ export function getDefaultArgs(): Args {
         rejectDateType: false,
         id: "",
         defaultNumberType: "number",
+        tsNodeRegister: false,
     };
 }
 
@@ -82,6 +83,7 @@ export type Args = {
     rejectDateType: boolean;
     id: string;
     defaultNumberType: "number" | "integer";
+    tsNodeRegister: boolean;
 };
 
 export type PartialArgs = Partial<Args>;
@@ -1494,6 +1496,10 @@ export function buildGenerator(
         if (args.hasOwnProperty(pref)) {
             settings[pref] = args[pref];
         }
+    }
+
+    if (args.tsNodeRegister) {
+        require("ts-node/register");
     }
 
     let diagnostics: ReadonlyArray<ts.Diagnostic> = [];

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -172,27 +172,28 @@ function unique(arr: string[]): string[] {
 }
 
 /**
- * Resolve required file / object
+ * Resolve required file
  */
 function resolveRequiredFile(symbol: ts.Symbol, key: string, fileName: string, objectName: string): any {
-    var sourceFile = getSourceFile(symbol);
-    var requiredFileFullPath =
-        fileName === "."
+    const sourceFile = getSourceFile(symbol);
+    const requiredFilePath = /[.\/]+/.test(fileName)
+        ? fileName === "."
             ? path.resolve(sourceFile.fileName)
-            : path.resolve(path.dirname(sourceFile.fileName), fileName);
-    var requiredFile = require(requiredFileFullPath);
+            : path.resolve(path.dirname(sourceFile.fileName), fileName)
+        : fileName;
+    const requiredFile = require(requiredFilePath);
     if (!requiredFile) {
-        throw Error("File couldn't be loaded");
+        throw Error("Required: File couldn't be loaded");
     }
-    var requiredObject = objectName ? requiredFile[objectName] : requiredFile.default;
+    const requiredObject = objectName ? requiredFile[objectName] : requiredFile.default;
     if (requiredObject === undefined) {
-        throw Error("Required variable is undefined");
+        throw Error("Required: Variable is undefined");
     }
     if (typeof requiredObject === "function") {
-        throw Error("Can't use function as a variable");
+        throw Error("Required: Can't use function as a variable");
     }
     if (key === "examples" && !Array.isArray(requiredObject)) {
-        throw Error("Required variable isn't an array");
+        throw Error("Required: Variable isn't an array");
     }
     return requiredObject;
 }

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -7,7 +7,6 @@ import { JSONSchema7 } from "json-schema";
 export { Program, CompilerOptions, Symbol } from "typescript";
 
 const vm = require("vm");
-require("ts-node/register");
 
 const REGEX_FILE_NAME_OR_SPACE = /(\bimport\(".*?"\)|".*?")\.| /g;
 const REGEX_TSCONFIG_NAME = /^.*\.json$/;


### PR DESCRIPTION
Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`

This functionality allows you to enclose a variable (object, array,...) into your property. In my case I needed to have an interface and provide an example in generated JSON schema. But some examples are too big to write them in anotation and we even can't check them by tsc. With 'require' it allows you to import a real object, array, etc. into your provided property. Examples require an array, so when is defined **@examples** or **@TJS-examples** then you must require an array. Every 'require' will fail the JSON schema generation when there will be some errors. This 'require' functionality isn't limited only for the tag 'examples' (but can be easily changed in the code). For big projects and big interfaces is this 'require' functinality really needed.