### PR TITLE
Cache the generator to improve performance

### DIFF
--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1589,13 +1589,18 @@ export function buildGenerator(
     }
 }
 
+let generator: JsonSchemaGenerator | null | undefined;
+
 export function generateSchema(
     program: ts.Program,
     fullTypeName: string,
     args: PartialArgs = {},
-    onlyIncludeFiles?: string[]
+    onlyIncludeFiles?: string[],
+    cacheGenerator = false
 ): Definition | null {
-    const generator = buildGenerator(program, args, onlyIncludeFiles);
+    if (generator === undefined || !cacheGenerator) {
+        generator = buildGenerator(program, args, onlyIncludeFiles);
+    }
 
     if (generator === null) {
         return null;


### PR DESCRIPTION
This is a simple change, but in our case, it helped to reduce the tests time by ~95%.
This PR makes the generator being reused between `generateSchema` calls.

I do not use this library anywhere else than some tests in our code, so I may be missing other use-cases. If that is the case, please help me make it work for cases that you know serve everyone.
