### PR TITLE
feat: add bigint primitive type

### DIFF
--- a/test/programs/type-primitives/main.ts
+++ b/test/programs/type-primitives/main.ts
@@ -13,6 +13,8 @@ class MyObject {
     integer1: number      = 1;
     integer2: integer     = 1;
 
+    bigint1: bigint = null; // BigInt literals are not available when targeting lower than ES2020.
+
     string1: string       = "defaultValue";
 
     array1: Array<any>    = null;

--- a/test/programs/type-primitives/schema.json
+++ b/test/programs/type-primitives/schema.json
@@ -58,6 +58,7 @@
     "required": [
         "array1",
         "array2",
+        "bigint1",
         "boolean1",
         "integer1",
         "integer2",

--- a/test/programs/type-primitives/schema.json
+++ b/test/programs/type-primitives/schema.json
@@ -26,6 +26,10 @@
             "default": 1,
             "type": "integer"
         },
+        "bigint1": {
+            "default": null,
+            "type": "bigint"
+        },
         "number1": {
             "default": 1,
             "type": "number"

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -640,6 +640,8 @@ export class JsonSchemaGenerator {
                     reffedType?.getName() === "integer" ||
                     defaultNumberType === "integer";
                 definition.type = isInteger ? "integer" : "number";
+            } else if (flags & ts.TypeFlags.BigInt) {
+                definition.type = "bigint";
             } else if (flags & ts.TypeFlags.Boolean) {
                 definition.type = "boolean";
             } else if (flags & ts.TypeFlags.Null) {


### PR DESCRIPTION
source:
```ts
class MyObject {
    bigint1: bigint;
}
```

translates to:
```json
{
    "$schema": "http://json-schema.org/draft-07/schema#",
    "properties": {
        "bigint1": {
            "type": "bigint"
        }
    }
}
```

- [x] I've updated the ``test-primitives`` test