### PR TITLE
Clear reffered symbols before generating schemas.

### DIFF
--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1385,6 +1385,9 @@ export class JsonSchemaGenerator {
         if (!this.allSymbols[symbolName]) {
             throw new Error(`type ${symbolName} not found`);
         }
+
+        this.reffedDefinitions = { }
+
         const def = this.getTypeDefinition(
             this.allSymbols[symbolName],
             this.args.topRef,
@@ -1415,6 +1418,8 @@ export class JsonSchemaGenerator {
         if (id) {
             root["$id"] = id;
         }
+
+        this.reffedDefinitions = { }
 
         for (const symbolName of symbolNames) {
             root.definitions[symbolName] = this.getTypeDefinition(

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1386,7 +1386,7 @@ export class JsonSchemaGenerator {
             throw new Error(`type ${symbolName} not found`);
         }
 
-        this.reffedDefinitions = { }
+        this.reffedDefinitions = { };
 
         const def = this.getTypeDefinition(
             this.allSymbols[symbolName],
@@ -1419,7 +1419,7 @@ export class JsonSchemaGenerator {
             root["$id"] = id;
         }
 
-        this.reffedDefinitions = { }
+        this.reffedDefinitions = { };
 
         for (const symbolName of symbolNames) {
             root.definitions[symbolName] = this.getTypeDefinition(


### PR DESCRIPTION
This allows to re-use an existing `generator` instance when using typescript-json-schema programatically.

Otherwise, the referred definitions continue to accumulate, leading to larger and larger schemas with unnecessary definitions.