### PR TITLE
Update TypeScript to v4.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "glob": "^7.1.7",
     "json-stable-stringify": "^1.0.1",
     "ts-node": "^10.2.1",
-    "typescript": "~4.2.3",
+    "typescript": "~4.4.4",
     "yargs": "^17.1.1"
   },
   "devDependencies": {
@@ -69,7 +69,7 @@
   "scripts": {
     "prepublishOnly": "yarn build",
     "test": "yarn build && mocha -t 5000 --require source-map-support/register dist/test",
-    "debug": "ts-node --inspect=19248 --debug-brk typescript-json-schema-cli.ts",
+    "debug": "node --inspect=19248 --inspect-brk -r ts-node/register typescript-json-schema-cli.ts",
     "docs": "./update-docs.js",
     "run": "ts-node typescript-json-schema-cli.ts",
     "build": "tsc -p .",

--- a/yarn.lock
+++ b/yarn.lock
@@ -913,10 +913,10 @@ type-detect@^4.0.0, type-detect@^4.0.5:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-typescript@~4.2.3:
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.2.4.tgz#8610b59747de028fda898a8aef0e103f156d0961"
-  integrity sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==
+typescript@~4.4.4:
+  version "4.4.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
+  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
This PR updates `typescript` dependency to `~4.4.4` which allows to parse new constructs like `override` keyword.

Currently some tests are failing on `master` branch when running locally but these changes does not seem to change test results.
