### PR TITLE
date custom formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ yarn-error.log
 .#*
 dist/
 .DS_Store
+.history/

--- a/test/programs/dates/main.ts
+++ b/test/programs/dates/main.ts
@@ -3,4 +3,12 @@ type DateAlias = Date;
 interface MyObject {
     var1: Date;
     var2: DateAlias;
+    /**
+     * @format date
+     */
+    var3: Date;
+    /**
+     * @format date
+     */
+    var4: DateAlias;
 }

--- a/test/programs/dates/schema.json
+++ b/test/programs/dates/schema.json
@@ -8,11 +8,21 @@
         "var2": {
             "format": "date-time",
             "type": "string"
+        },
+        "var3": {
+            "format": "date",
+            "type": "string"
+        },
+        "var4": {
+            "format": "date",
+            "type": "string"
         }
     },
     "required": [
         "var1",
-        "var2"
+        "var2",
+        "var3",
+        "var4"
     ],
     "type": "object"
 }

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -655,7 +655,7 @@ export class JsonSchemaGenerator {
                 // no type restriction, so that anything will match
             } else if (propertyTypeString === "Date" && !this.args.rejectDateType) {
                 definition.type = "string";
-                definition.format = "date-time";
+                definition.format = definition.format || "date-time";
             } else if (propertyTypeString === "object") {
                 definition.type = "object";
                 definition.properties = {};


### PR DESCRIPTION
Make 'Date' fields able to define custom formats.

Source:
```typescript
interface Example {
  /**
   * @format date
   */
  birthday: Date;
}
```

translates to:
```json
{
  "$schema": "http://json-schema.org/draft-07/schema#",
  "properties": {
      "birthday": {
          "format": "date",
          "type": "string"
      }
  },
  "type": "object"
}
```
