### PR TITLE
fix: avoid unrelated definitions when reusing generator

### DIFF
--- a/test/programs/no-unrelated-definitions/main.ts
+++ b/test/programs/no-unrelated-definitions/main.ts
@@ -1,0 +1,15 @@
+export interface MyObject {
+  sub: SomeDefinition;
+}
+
+interface SomeDefinition {
+  is: string;
+}
+
+export interface MyOtherObject {
+  sub: SomeOtherDefinition;
+}
+
+interface SomeOtherDefinition {
+  is: string;
+}

--- a/test/programs/no-unrelated-definitions/schema.MyObject.json
+++ b/test/programs/no-unrelated-definitions/schema.MyObject.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "SomeDefinition": {
+      "type": "object",
+      "properties": {
+        "is": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "properties": {
+      "sub": {
+          "$ref": "#/definitions/SomeDefinition"
+      }
+  },
+  "type": "object"
+}

--- a/test/programs/no-unrelated-definitions/schema.MyOtherObject.json
+++ b/test/programs/no-unrelated-definitions/schema.MyOtherObject.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "SomeOtherDefinition": {
+      "type": "object",
+      "properties": {
+        "is": {
+          "type": "string"
+        }
+      }
+    }
+  },
+  "properties": {
+      "sub": {
+          "$ref": "#/definitions/SomeOtherDefinition"
+      }
+  },
+  "type": "object"
+}

--- a/test/programs/no-unrelated-definitions/tsconfig.json
+++ b/test/programs/no-unrelated-definitions/tsconfig.json
@@ -1,0 +1,6 @@
+{
+    "compilerOptions": {
+        "target": "es5",
+    },
+    "include": ["main.ts"]
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -464,3 +464,21 @@ describe("Functionality 'required' in annotation", () => {
         tsNodeRegister: true,
     });
 });
+
+describe("when reusing a generator", () => {
+  it("should not add unrelated definitions to schemas", () => {
+    // regression test for https://github.com/YousefED/typescript-json-schema/issues/465
+    const testProgramPath = BASE + "no-unrelated-definitions/";
+    const program = TJS.programFromConfig(resolve(testProgramPath + "tsconfig.json"));
+    const generator = TJS.buildGenerator(program);
+
+    ["MyObject", "MyOtherObject"].forEach(symbolName => {
+      const expectedSchemaString = readFileSync(testProgramPath + `schema.${symbolName}.json`, "utf8");
+      const expectedSchemaObject = JSON.parse(expectedSchemaString);
+
+      const actualSchemaObject = generator?.getSchemaForSymbol(symbolName);
+
+      assert.deepEqual(actualSchemaObject, expectedSchemaObject, `The schema for ${symbolName} is not as expected`);
+    });
+  });
+});

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -527,6 +527,17 @@ export class JsonSchemaGenerator {
         return false;
     }
 
+    private resetSchemaSpecificProperties() {
+      this.reffedDefinitions = {};
+      this.typeIdsByName = {};
+      this.typeNamesById = {};
+
+      // restore schema overrides
+      this.schemaOverrides.forEach((value, key) => {
+        this.reffedDefinitions[key] = value;
+      });
+    }
+
     /**
      * Parse the comments of a symbol into the definition and other annotations.
      */
@@ -1386,7 +1397,6 @@ export class JsonSchemaGenerator {
     }
 
     public setSchemaOverride(symbolName: string, schema: Definition): void {
-        this.reffedDefinitions[symbolName] = schema;
         this.schemaOverrides.set(symbolName, schema);
     }
 
@@ -1394,6 +1404,9 @@ export class JsonSchemaGenerator {
         if (!this.allSymbols[symbolName]) {
             throw new Error(`type ${symbolName} not found`);
         }
+
+        this.resetSchemaSpecificProperties();
+
         const def = this.getTypeDefinition(
             this.allSymbols[symbolName],
             this.args.topRef,
@@ -1419,6 +1432,9 @@ export class JsonSchemaGenerator {
             $schema: "http://json-schema.org/draft-07/schema#",
             definitions: {},
         };
+
+        this.resetSchemaSpecificProperties();
+
         const id = this.args.id;
 
         if (id) {


### PR DESCRIPTION
This PR fixes #465 and makes #436 obsolete.