### PR TITLE
fix(deps): update dependency typescript to ~4.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "glob": "^7.1.7",
     "safe-stable-stringify": "^2.2.0",
     "ts-node": "^10.2.1",
-    "typescript": "~4.5.0",
+    "typescript": "~4.6.0",
     "yargs": "^17.1.1",
     "path-equal": "1.1.2"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,10 +888,10 @@ type-detect@^4.0.0, type-detect@^4.0.5:
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-typescript@~4.5.0:
-  version "4.5.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.4.tgz#a17d3a0263bf5c8723b9c52f43c5084edf13c2e8"
-  integrity sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==
+typescript@~4.6.0:
+  version "4.6.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
+  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- ~~Provide a test case & update the documentation in the `Readme.md`~~ - N/A

Context:

- Inspired by https://github.com/YousefED/typescript-json-schema/pull/456
- [TypeScript 4.6 release announcement](https://devblogs.microsoft.com/typescript/announcing-typescript-4-6/)


Out of scope:
 - [EOF + dependencies order in package.json /  autocorrections in yarn.lock](https://github.com/YousefED/typescript-json-schema/commit/ae6ddbad41f4ccac49c0ab701171db9eed89f2f1) (I can add these to the PR if desired)