### PR TITLE
Change package.json license to new format

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,11 +32,7 @@
     "type": "git",
     "url": "git@github.com:YousefED/typescript-json-schema.git"
   },
-  "licenses": [
-    {
-      "type": "BSD-3-Clause"
-    }
-  ],
+  "license": "BSD-3-Clause",
   "keywords": [
     "typescript",
     "json",


### PR DESCRIPTION
Updated license to "new" SPDX-based format as per https://docs.npmjs.com/cli/v6/configuring-npm/package-json/#license .

GitHub editor seems to have snuck in a line-end to the end-of-file, hopefully that's not an issue.

Closes #478 
