### PR TITLE
Fix crashing on tslib not being installed (#483)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/json-schema": "^7.0.9",
     "@types/node": "^16.9.2",
     "glob": "^7.1.7",
-    "path-equal": "1.1.2",
+    "path-equal": "^1.1.2",
     "safe-stable-stringify": "^2.2.0",
     "ts-node": "^10.2.1",
     "typescript": "~4.6.0",


### PR DESCRIPTION
The best commits are those that fix a crash by adding one character.
Oops.