### PR TITLE
fix: don't remove whitespaces around inline tags in comments

### DIFF
--- a/test/programs/comments-inline-tags/main.ts
+++ b/test/programs/comments-inline-tags/main.ts
@@ -1,0 +1,13 @@
+/**
+ * This is MyOtherObject
+ */
+interface MyOtherObject {
+  prop1: string;
+}
+
+/**
+ * This is MyObject. It extends {@link MyOtherObject} and {@link SomeOtherObject}.
+ */
+interface MyObject extends MyOtherObject {
+  prop2: string;
+}

--- a/test/programs/comments-inline-tags/schema.json
+++ b/test/programs/comments-inline-tags/schema.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "This is MyObject. It extends {@link MyOtherObject} and {@link SomeOtherObject}.",
+    "properties": {
+        "prop1": {
+            "type": "string"
+        },
+        "prop2": {
+            "type": "string"
+        }
+    },
+    "required": [
+        "prop1",
+        "prop2"
+    ],
+    "type": "object"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -301,6 +301,7 @@ describe("schema", () => {
             aliasRef: true,
         });
         assertSchema("comments-from-lib", "MyObject");
+        assertSchema("comments-inline-tags", "MyObject");
     });
 
     describe("types", () => {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -541,10 +541,17 @@ export class JsonSchemaGenerator {
 
             if (comments.length) {
                 definition.description = comments
-                    .map((comment) =>
-                        comment.kind === "lineBreak" ? comment.text : comment.text.trim().replace(/\r\n/g, "\n")
-                    )
-                    .join("");
+                    .map((comment) => {
+                      const newlineNormalizedComment = comment.text.replace(/\r\n/g, "\n");
+
+                      // If a comment contains a "{@link XYZ}" inline tag that could not be
+                      // resolved by the TS checker, then this comment will contain a trailing
+                      // whitespace that we need to remove.
+                      if (comment.kind === 'linkText') return newlineNormalizedComment.trim();
+
+                      return newlineNormalizedComment;
+                    })
+                    .join("").trim();
             }
         }
 

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -556,7 +556,9 @@ export class JsonSchemaGenerator {
                       // If a comment contains a "{@link XYZ}" inline tag that could not be
                       // resolved by the TS checker, then this comment will contain a trailing
                       // whitespace that we need to remove.
-                      if (comment.kind === 'linkText') return newlineNormalizedComment.trim();
+                      if (comment.kind === "linkText") {
+                        return newlineNormalizedComment.trim();
+                      }
 
                       return newlineNormalizedComment;
                     })


### PR DESCRIPTION
Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`

---

### What does this PR fix?
This PR fixes the parsing of comments with [inline tags](https://tsdoc.org/pages/spec/tag_kinds/#inline-tags). It broke due to a recent TypeScript update (I don't have any exact reference, neither changelog, nor PR, nor commit, sorry). With this update they introduced a special format for `@link` inline tags which, in combination with our `comment.text.trim()`, resulted in missing whitespaces in the extracted comment.

This still worked properly with `typescript-json-schema@0.51.0`, so the TypeScript update apparently happened slightly afterwards.

After the TypeScript update, this is what we get from `symbol.getDocumentationComment()`:
![image](https://user-images.githubusercontent.com/7970458/174286385-50786340-c82a-4f80-a6a1-f6ee98310753.png)

Before the TypeScript update it looked like this:
![image](https://user-images.githubusercontent.com/7970458/174286421-67e63654-08a1-4196-ad9e-64eb40b6c959.png)

This resulted in `description`s in the generated JSON schemas that looked like this:
```
This is a description with a{@linkSomeOtherType}\nThe description contains a blank line [...]
```
while previously they looked like this:
```
This is a description with a {@link SomeOtherType}\nThe description contains a blank line [...]
```

Updating past v0.51.0 led to a lot of changes in our generated schemas and we weren't able to update `typescript-json-schema` in our projects.

### How does it fix it?
So far there was code to check if a comment is of kind `lineBreak`. I wasn't able to find/come up with a comment that would contain this kind of comment-node, so I decided to remove it entirely. Instead I added a check for a `linkText` comment-node, which (in some cases) has an additional trailing whitespace that we need to `.trim()` (I consider this a TypeScript bug, will open an issue in their repository). I also moved the previous `.trim()` to the entire (mapped & joined) comment to remove any leading/trailing whitespaces/newlines.