### PR TITLE
Fix issues with `isFromDefaultLib()` function

### DIFF
--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -520,7 +520,7 @@ export class JsonSchemaGenerator {
 
     private isFromDefaultLib(symbol: ts.Symbol) {
         const declarations = symbol.getDeclarations();
-        if (declarations && declarations.length > 0) {
+        if (declarations && declarations.length > 0 && declarations[0].parent) {
             return declarations[0].parent.getSourceFile().hasNoDefaultLib;
         }
         return false;


### PR DESCRIPTION
In some cases it will try to call `declarations[0].parent.getSourceFile()` when `parent` is undefined.

This simply adds another condition to the if statement so it will not try unless parent is defined.