### PR TITLE
Add skiplibcheck as an option for TypeScript compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Options:
   --required            Create required array for non-optional properties.           [boolean] [default: false]
   --strictNullChecks    Make values non-nullable by default.                         [boolean] [default: false]
   --esModuleInterop     Use esModuleInterop when loading typescript modules.         [boolean] [default: false]
+  --skipLibCheck        Use skipLibCheck when loading typescript modules.            [boolean] [default: false]
   --useTypeOfKeyword    Use `typeOf` keyword (https://goo.gl/DC6sni) for functions.  [boolean] [default: false]
   --out, -o             The output file, defaults to using stdout
   --validationKeywords  Provide additional validation keywords to include            [array]   [default: []]

--- a/typescript-json-schema-cli.ts
+++ b/typescript-json-schema-cli.ts
@@ -30,6 +30,8 @@ export function run() {
             .describe("strictNullChecks", "Make values non-nullable by default.")
         .boolean("esModuleInterop").default("esModuleInterop", defaultArgs.esModuleInterop)
             .describe("esModuleInterop", "Use esModuleInterop when loading typescript modules.")
+        .boolean("skipLibCheck").default("skipLibCheck", defaultArgs.skipLibCheck)
+            .describe("skipLibCheck", "Use skipLibCheck when loading typescript modules.")
         .boolean("ignoreErrors").default("ignoreErrors", defaultArgs.ignoreErrors)
             .describe("ignoreErrors", "Generate even if the program has errors.")
         .alias("out", "o")
@@ -65,6 +67,7 @@ export function run() {
         required: args.required,
         strictNullChecks: args.strictNullChecks,
         esModuleInterop: args.esModuleInterop,
+        skipLibCheck: args.skipLibCheck,
         ignoreErrors: args.ignoreErrors,
         out: args.out,
         validationKeywords: args.validationKeywords,

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -48,6 +48,7 @@ export function getDefaultArgs(): Args {
         required: false,
         strictNullChecks: false,
         esModuleInterop: false,
+        skipLibCheck: false,
         ignoreErrors: false,
         out: "",
         validationKeywords: [],
@@ -77,6 +78,7 @@ export type Args = {
     required: boolean;
     strictNullChecks: boolean;
     esModuleInterop: boolean;
+    skipLibCheck: boolean;
     ignoreErrors: boolean;
     out: string;
     validationKeywords: string[];
@@ -1711,6 +1713,7 @@ export async function exec(filePattern: string, fullTypeName: string, args = get
         program = getProgramFromFiles(onlyIncludeFiles, {
             strictNullChecks: args.strictNullChecks,
             esModuleInterop: args.esModuleInterop,
+            skipLibCheck: args.skipLibCheck,
         });
         onlyIncludeFiles = onlyIncludeFiles.map(normalizeFileName);
     }


### PR DESCRIPTION
`skipLibCheck` is required for compatibility with our codebase to avoid TypeScript "Duplicate identifier" errors when running `typescript-json-schema`. 