### PR TITLE
Fix recursive intersecting types bug with noExtraProps, probably fixes Issue #281

### DIFF
--- a/test/programs/type-intersection-recursive-no-additional/main.ts
+++ b/test/programs/type-intersection-recursive-no-additional/main.ts
@@ -1,0 +1,9 @@
+type MyRecursiveNode = {
+    next?: MyNode;
+}
+
+type MyNode = {
+    val: string;
+} & MyRecursiveNode;
+
+type MyLinkedList = MyNode;

--- a/test/programs/type-intersection-recursive-no-additional/schema.json
+++ b/test/programs/type-intersection-recursive-no-additional/schema.json
@@ -1,0 +1,21 @@
+{
+    "$ref": "#/definitions/MyNode",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "definitions": {
+        "MyNode": {
+            "additionalProperties": false,
+            "properties": {
+                "next": {
+                    "$ref": "#/definitions/MyNode"
+                },
+                "val": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "val"
+            ],
+            "type": "object"
+        }
+    }
+}

--- a/test/programs/type-intersection-recursive/schema.json
+++ b/test/programs/type-intersection-recursive/schema.json
@@ -1,4 +1,5 @@
 {
+    "$ref": "#/definitions/Foo",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "definitions": {
         "ChildFoo": {

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -259,7 +259,10 @@ describe("schema", () => {
         });
         assertSchema("type-union-tagged", "Shape");
         assertSchema("type-aliases-union-namespace", "MyModel");
-        assertSchema("type-intersection-recursive", "*");
+        assertSchema("type-intersection-recursive", "Foo");
+        assertSchema("type-intersection-recursive-no-additional", "MyLinkedList", {
+            noExtraProps: true,
+        });
     });
 
     describe("annotations", () => {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1291,7 +1291,6 @@ export class JsonSchemaGenerator {
         // Handle recursive types
         if (!isRawType || !!typ.aliasSymbol) {
             if (this.recursiveTypeRef.has(fullTypeName) && !forceNotRef) {
-                // this.recursiveTypeRef.delete(fullTypeName);
                 asRef = true;
             } else {
                 this.recursiveTypeRef.set(fullTypeName, definition);

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1184,7 +1184,8 @@ export class JsonSchemaGenerator {
         unionModifier: string = "anyOf",
         prop?: ts.Symbol,
         reffedType?: ts.Symbol,
-        pairedSymbol?: ts.Symbol
+        pairedSymbol?: ts.Symbol,
+        forceNotRef: boolean = false
     ): Definition {
         const definition: Definition = {}; // real definition
 
@@ -1289,8 +1290,8 @@ export class JsonSchemaGenerator {
 
         // Handle recursive types
         if (!isRawType || !!typ.aliasSymbol) {
-            if (this.recursiveTypeRef.has(fullTypeName)) {
-                this.recursiveTypeRef.delete(fullTypeName);
+            if (this.recursiveTypeRef.has(fullTypeName) && !forceNotRef) {
+                // this.recursiveTypeRef.delete(fullTypeName);
                 asRef = true;
             } else {
                 this.recursiveTypeRef.set(fullTypeName, definition);
@@ -1348,12 +1349,13 @@ export class JsonSchemaGenerator {
 
                         const types = (<ts.IntersectionType>typ).types;
                         for (const member of types) {
-                            const other = this.getTypeDefinition(member, false);
+                            const other = this.getTypeDefinition(member, false, undefined, undefined, undefined, undefined, true);
                             definition.type = other.type; // should always be object
                             definition.properties = {
                                 ...definition.properties,
                                 ...other.properties,
                             };
+
                             if (Object.keys(other.default || {}).length > 0) {
                                 definition.default = extend(definition.default || {}, other.default);
                             }
@@ -1389,7 +1391,7 @@ export class JsonSchemaGenerator {
             }
         }
 
-        if (this.recursiveTypeRef.get(fullTypeName) === definition) {
+        if (this.recursiveTypeRef.get(fullTypeName) === definition && !forceNotRef) {
             this.recursiveTypeRef.delete(fullTypeName);
             // If the type was recursive (there is reffedDefinitions) - lets replace it to reference
             if (this.reffedDefinitions[fullTypeName]) {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1290,6 +1290,7 @@ export class JsonSchemaGenerator {
         // Handle recursive types
         if (!isRawType || !!typ.aliasSymbol) {
             if (this.recursiveTypeRef.has(fullTypeName)) {
+                this.recursiveTypeRef.delete(fullTypeName);
                 asRef = true;
             } else {
                 this.recursiveTypeRef.set(fullTypeName, definition);


### PR DESCRIPTION
This fixes a bug that occurs when using recursive and intersecting types with the noExtraProps flag at the same time. For example:

```
type BNode = {
    node?: BNode;
}

type ANode = {
    val: number;
} & BNode;

type CNode = {
    val: string;
} & BNode;

type Tree = {
    a: number;
    $schema?: string;
} & (CNode | ANode);
```

The bug occurs because when iterating over the intersecting types, if one of the types is recursive it is returned as a ref, and this cannot be added to the type being built. The fix makes sure that in this case, a ref isnt returned