### PR TITLE
fix: include Title in referenced definitions

### DIFF
--- a/test/programs/annotation-title/main.ts
+++ b/test/programs/annotation-title/main.ts
@@ -10,6 +10,8 @@ interface MyObject {
      * @title empty#
      */
     empty;
-
+    /**
+     * @title filled
+     */
     filled: MySubObject;
 }

--- a/test/programs/annotation-title/main.ts
+++ b/test/programs/annotation-title/main.ts
@@ -5,6 +5,10 @@ interface MySubObject {
     a: boolean;
 }
 
+interface AnotherSubObject {
+    b: boolean;
+}
+
 interface MyObject {
     /**
      * @title empty#
@@ -14,4 +18,5 @@ interface MyObject {
      * @title filled
      */
     filled: MySubObject;
+    nonTitled: AnotherSubObject;
 }

--- a/test/programs/annotation-title/schema.json
+++ b/test/programs/annotation-title/schema.json
@@ -1,6 +1,15 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "definitions": {
+    "AnotherSubObject": {
+      "properties": {
+        "b": {
+          "type": "boolean"
+        }
+      },
+      "required": ["b"],
+      "type": "object"
+    },
     "MySubObject": {
       "title": "filled#",
       "type": "object",
@@ -17,8 +26,11 @@
     "filled": {
       "$ref": "#/definitions/MySubObject",
       "title": "filled"
+    },
+    "nonTitled": {
+      "$ref": "#/definitions/AnotherSubObject"
     }
   },
-  "required": ["empty", "filled"],
+  "required": ["empty", "filled", "nonTitled"],
   "type": "object"
 }

--- a/test/programs/annotation-title/schema.json
+++ b/test/programs/annotation-title/schema.json
@@ -15,7 +15,8 @@
       "title": "empty#"
     },
     "filled": {
-      "$ref": "#/definitions/MySubObject"
+      "$ref": "#/definitions/MySubObject",
+      "title": "filled"
     }
   },
   "required": ["empty", "filled"],

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -438,6 +438,7 @@ const annotationKeywords: { [k in keyof typeof validationKeywords]?: true } = {
     description: true,
     default: true,
     examples: true,
+    title: true,
     // A JSDoc $ref annotation can appear as a $ref.
     $ref: true,
 };


### PR DESCRIPTION
A PR to address the following issue: https://github.com/YousefED/typescript-json-schema/issues/533

Updated the tests to check if titles will be added to the ref types and ran the full suite of test to ensure that the changes do not affect other areas of code

<img width="556" alt="image" src="https://github.com/YousefED/typescript-json-schema/assets/42404619/d6adc577-24ef-4941-9fa3-7726edc16d12">

Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`
