### PR TITLE
Update path-equal so users don't need to install tslib

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@types/json-schema": "^7.0.9",
     "@types/node": "^16.9.2",
     "glob": "^7.1.7",
-    "path-equal": "^1.1.2",
+    "path-equal": "^1.2.5",
     "safe-stable-stringify": "^2.2.0",
     "ts-node": "^10.9.1",
     "typescript": "~4.9.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -673,10 +673,10 @@
   dependencies:
     "p-limit" "^3.0.2"
 
-"path-equal@^1.1.2":
-  "integrity" "sha512-AUJvbcle1Zgb1TgtftHYknlrgrSYyI1ytrYgSbKUHSybwqUDnbD2cw9PIWivuMvsN+GTXmr/DRN4VBXpHG6aGg=="
-  "resolved" "https://registry.npmjs.org/path-equal/-/path-equal-1.2.2.tgz"
-  "version" "1.2.2"
+"path-equal@^1.2.5":
+  "integrity" "sha512-i73IctDr3F2W+bsOWDyyVm/lqsXO47aY9nsFZUjTT/aljSbkxHxxCoyZ9UUrM8jK0JVod+An+rl48RCsvWM+9g=="
+  "resolved" "https://registry.yarnpkg.com/path-equal/-/path-equal-1.2.5.tgz#9fcbdd5e5daee448e96f43f3bac06c666b5e982a"
+  "version" "1.2.5"
 
 "path-exists@^4.0.0":
   "integrity" "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="


### PR DESCRIPTION
path-equal < 1.2 had a phantom dependency to tslib (https://github.com/unional/path-equal/pull/57), which is not a problem if your project is written in TypeScript. However, if you're flying with vanilla JS or JS with JSDocs with TypeScript, it will fail if you don't have tslib installed.

Please:
- [ ] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [ ] Provide a test case & update the documentation in the `Readme.md`
