### PR TITLE
Remove check for !forceNotRef

### DIFF
--- a/test/programs/no-ref/main.ts
+++ b/test/programs/no-ref/main.ts
@@ -1,0 +1,9 @@
+type MySubType = {
+    id: string;
+};
+
+export type MyModule = {
+    address: MySubType & { extraProp: number };
+    address2: MySubType;
+    address3: MySubType;
+};

--- a/test/programs/no-ref/schema.json
+++ b/test/programs/no-ref/schema.json
@@ -1,0 +1,41 @@
+{
+  "type": "object",
+  "properties": {
+    "address": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "extraProp": {
+          "type": "number"
+        }
+      },
+      "required": ["extraProp", "id"]
+    },
+    "address2": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": ["id"]
+    },
+    "address3": {
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "string"
+        }
+      },
+      "required": ["id"]
+    }
+  },
+  "additionalProperties": false,
+  "required": ["address", "address2", "address3"],
+  "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -266,6 +266,15 @@ describe("schema", () => {
         });
     });
 
+    describe("no-refs", () => {
+        assertSchema("no-ref", "MyModule", {
+            ref: false,
+            aliasRef: false,
+            topRef: false,
+            noExtraProps: true,
+        });
+    });
+
     describe("annotations", () => {
         assertSchema("annotation-default", "MyObject");
         assertSchema("annotation-ref", "MyObject", {}, undefined, undefined, {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1422,7 +1422,7 @@ export class JsonSchemaGenerator {
             }
         }
 
-        if (this.recursiveTypeRef.get(fullTypeName) === definition && !forceNotRef) {
+        if (this.recursiveTypeRef.get(fullTypeName) === definition) {
             this.recursiveTypeRef.delete(fullTypeName);
             // If the type was recursive (there is reffedDefinitions) - lets replace it to reference
             if (this.reffedDefinitions[fullTypeName]) {


### PR DESCRIPTION
This check that was introduced in [#281](https://github.com/YousefED/typescript-json-schema/pull/526) will add refs even tho option refs:false has been defined together with noExtraProps.
Removing this check reverts to prior behaviour and does not break any tests.

maybe @mambla can shed some light on why this check was added.