### PR TITLE
Single union case shouldn't overwrite existing properties

### DIFF
--- a/test/programs/type-union-strict-null-keep-description/main.ts
+++ b/test/programs/type-union-strict-null-keep-description/main.ts
@@ -1,0 +1,22 @@
+/**
+ * Description of InnerObject.
+ */
+type InnerObject = {
+	/**
+	 * Description of foo.
+	 */
+	foo: string;
+};
+
+/**
+ * Description of MyObject.
+ */
+type MyObject = {
+
+	inner1?: InnerObject;
+
+	/**
+	 * Override description.
+	 */
+	inner2?: InnerObject;
+};

--- a/test/programs/type-union-strict-null-keep-description/schema.json
+++ b/test/programs/type-union-strict-null-keep-description/schema.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Description of MyObject.",
+    "properties": {
+        "inner1": {
+            "description": "Description of InnerObject.",
+            "properties": {
+                "foo": {
+                    "description": "Description of foo.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "foo"
+            ],
+            "type": "object"
+        },
+        "inner2": {
+            "description": "Override description.",
+            "properties": {
+                "foo": {
+                    "description": "Description of foo.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "foo"
+            ],
+            "type": "object"
+        }
+    },
+    "type": "object"
+}
+

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -264,6 +264,9 @@ describe("schema", () => {
         assertSchema("type-intersection-recursive-no-additional", "MyLinkedList", {
             noExtraProps: true,
         });
+        assertSchema("type-union-strict-null-keep-description", "MyObject", undefined, {
+            strictNullChecks: true,
+        });
     });
 
     describe("no-refs", () => {

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -969,7 +969,7 @@ export class JsonSchemaGenerator {
 
         if (schemas.length === 1) {
             for (const k in schemas[0]) {
-                if (schemas[0].hasOwnProperty(k)) {
+                if (schemas[0].hasOwnProperty(k) && !definition.hasOwnProperty(k)) {
                     definition[k] = schemas[0][k];
                 }
             }


### PR DESCRIPTION
In the case of a single union, we were just copying all properties across. This can overwrite a pre-existing field, in particular a more-specific description that has been specified on some including type.

This came up in a project where enabling `strictNullChecks` caused a bunch of descriptions to change for seemingly no reason.

Please:
- [X] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [X] Provide a test case & update the documentation in the `Readme.md`
