### PR TITLE
Overcame typescript bug in property start with multi underscores

### DIFF
--- a/api.md
+++ b/api.md
@@ -1061,6 +1061,29 @@ export type Main = {
 ```
 
 
+## [key-in-key-of-multi-underscores](./test/programs/key-in-key-of-multi-underscores)
+
+```ts
+type Util = {
+    __2Underscores: {
+        utilDeepKey2: string;
+    };
+    ___3Underscores: {
+        utilDeepKey3: string;
+    };
+    ____4Underscores: {
+        utilDeepKey4: string;
+    };
+};
+
+export type Main = {
+    [Key in keyof Util]: {
+        [key: string]: Util[Key];
+    };
+};
+```
+
+
 ## [key-in-key-of-single](./test/programs/key-in-key-of-single)
 
 ```ts
@@ -1213,6 +1236,21 @@ export interface Never {
   neverProp: never;
   propA: string;
 }
+```
+
+
+## [no-ref](./test/programs/no-ref)
+
+```ts
+type MySubType = {
+    id: string;
+};
+
+export type MyModule = {
+    address: MySubType & { extraProp: number };
+    address2: MySubType;
+    address3: MySubType;
+};
 ```
 
 
@@ -1995,6 +2033,34 @@ interface MyObject {
     var1: MyType1;
     var2: MyType2;
 }
+```
+
+
+## [type-union-strict-null-keep-description](./test/programs/type-union-strict-null-keep-description)
+
+```ts
+/**
+ * Description of InnerObject.
+ */
+type InnerObject = {
+	/**
+	 * Description of foo.
+	 */
+	foo: string;
+};
+
+/**
+ * Description of MyObject.
+ */
+type MyObject = {
+
+	inner1?: InnerObject;
+
+	/**
+	 * Override description.
+	 */
+	inner2?: InnerObject;
+};
 ```
 
 

--- a/test/programs/key-in-key-of-multi-underscores/main.ts
+++ b/test/programs/key-in-key-of-multi-underscores/main.ts
@@ -1,0 +1,17 @@
+type Util = {
+    __2Underscores: {
+        utilDeepKey2: string;
+    };
+    ___3Underscores: {
+        utilDeepKey3: string;
+    };
+    ____4Underscores: {
+        utilDeepKey4: string;
+    };
+};
+
+export type Main = {
+    [Key in keyof Util]: {
+        [key: string]: Util[Key];
+    };
+};

--- a/test/programs/key-in-key-of-multi-underscores/schema.json
+++ b/test/programs/key-in-key-of-multi-underscores/schema.json
@@ -1,0 +1,53 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "__2Underscores": {
+            "additionalProperties": {
+                "properties": {
+                    "utilDeepKey2": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "utilDeepKey2"
+                ],
+                "type": "object"
+            },
+            "type": "object"
+        },
+        "___3Underscores": {
+            "additionalProperties": {
+                "properties": {
+                    "utilDeepKey3": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "utilDeepKey3"
+                ],
+                "type": "object"
+            },
+            "type": "object"
+        },
+        "____4Underscores": {
+            "additionalProperties": {
+                "properties": {
+                    "utilDeepKey4": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "utilDeepKey4"
+                ],
+                "type": "object"
+            },
+            "type": "object"
+        }
+    },
+    "required": [
+        "__2Underscores",
+        "___3Underscores",
+        "____4Underscores"
+    ],
+    "type": "object"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -464,6 +464,7 @@ describe("schema", () => {
     describe("key in key of", () => {
         assertSchema("key-in-key-of-single", "Main");
         assertSchema("key-in-key-of-multi", "Main");
+        assertSchema("key-in-key-of-multi-underscores", "Main");
     });
 });
 

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1085,16 +1085,10 @@ export class JsonSchemaGenerator {
                     const typ = this.tc.getTypeAtLocation(indexSignature.type!);
                     let def: Definition | undefined;
                     if (typ.flags & ts.TypeFlags.IndexedAccess) {
-                        const targetName: string = (<any>clazzType).mapper?.target?.value;
+                        const targetName = ts.escapeLeadingUnderscores((<any>clazzType).mapper?.target?.value);
                         const indexedAccessType = <ts.IndexedAccessType>typ;
-                        const symbols: Map<string, ts.Symbol> = (<any>indexedAccessType.objectType).members;
-                        let targetSymbol = symbols?.get(targetName);
-
-                        // it looks like a bug in typescript,
-                        // if property start with 2 underscores and more, in objectType.members, have a 1 unnecessary underscore
-                        if (!targetSymbol && targetName.startsWith("__")) {
-                            targetSymbol = symbols?.get(`_${targetName}`);
-                        }
+                        const symbols: Map<ts.__String, ts.Symbol> = (<any>indexedAccessType.objectType).members;
+                        const targetSymbol = symbols?.get(targetName);
 
                         if (targetSymbol) {
                             const targetNode = targetSymbol.getDeclarations()![0];

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1088,7 +1088,13 @@ export class JsonSchemaGenerator {
                         const targetName: string = (<any>clazzType).mapper?.target?.value;
                         const indexedAccessType = <ts.IndexedAccessType>typ;
                         const symbols: Map<string, ts.Symbol> = (<any>indexedAccessType.objectType).members;
-                        const targetSymbol = symbols?.get(targetName);
+                        let targetSymbol = symbols?.get(targetName);
+
+                        // it looks like a bug in typescript,
+                        // if property start with 2 underscores and more, in objectType.members, have a 1 unnecessary underscore
+                        if (!targetSymbol && targetName.startsWith("__")) {
+                            targetSymbol = symbols?.get(`_${targetName}`);
+                        }
 
                         if (targetSymbol) {
                             const targetNode = targetSymbol.getDeclarations()![0];


### PR DESCRIPTION
Please:
- [ V ] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [ V ] Provide a test case & update the documentation in the `Readme.md`

**what is here:**
as a continuation of #532 if one property start with two underscores or more, building schema are failed, 
it looks like a bug in typescript, have a 1 unnecessary underscore

