### PR TITLE
Fix type enum (without revert)

### DIFF
--- a/test/programs/type-literals/main.ts
+++ b/test/programs/type-literals/main.ts
@@ -1,0 +1,8 @@
+type MyObject = {
+    param1: "1" | "2" | "3";
+    param2: "1" | "2" | 3 | true;
+    /** @enum {string} */
+    param3: "1" | "2" | "3";
+    /** @enum {unknown} */
+    param4: "1" | "2" | 3 | true;
+};

--- a/test/programs/type-literals/schema.json
+++ b/test/programs/type-literals/schema.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "properties": {
+    "param1": {
+      "enum": ["1", "2", "3"],
+      "type": "string"
+    },
+    "param2": {
+      "enum": ["1", "2", 3, true]
+    },
+    "param3": {
+      "enum": ["1", "2", "3"],
+      "type": "string"
+    },
+    "param4": {
+      "enum": ["1", "2", 3, true]
+    }
+  },
+  "required": ["param1", "param2", "param3", "param4"],
+  "type": "object"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -221,6 +221,7 @@ describe("schema", () => {
         //     useTypeAliasRef: true,
         //     useRootRef: true
         // });
+        assertSchema("type-literals", "MyObject");
         assertSchema("type-no-aliases-recursive-topref", "MyAlias", {
             aliasRef: false,
             topRef: true,

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -969,7 +969,11 @@ export class JsonSchemaGenerator {
 
         if (schemas.length === 1) {
             for (const k in schemas[0]) {
-                if (schemas[0].hasOwnProperty(k) && !definition.hasOwnProperty(k)) {
+                if (schemas[0].hasOwnProperty(k)) {
+                    if (k === "description" && definition.hasOwnProperty(k)) {
+                        // If we already have a more specific description, don't overwrite it.
+                        continue;
+                    }
                     definition[k] = schemas[0][k];
                 }
             }


### PR DESCRIPTION
This is an alternative to #556, which fixes #555 by reverting *most* but not all of the change, restricting it to just `description`. It also incorporates the test from #556 to ensure this doesn't regress.

Please:
- [X] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [X] Provide a test case & update the documentation in the `Readme.md`
