### PR TITLE
Update to typescript 5.1

### DIFF
--- a/api.md
+++ b/api.md
@@ -607,6 +607,16 @@ export interface MyObject {
 ```
 
 
+## [const-keyword](./test/programs/const-keyword)
+
+```ts
+const fn = <const T>(value: T) =>
+  ({ value });
+
+export type Object = ReturnType<typeof fn<"value">>;
+```
+
+
 ## [custom-dates](./test/programs/custom-dates)
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "path-equal": "^1.2.5",
     "safe-stable-stringify": "^2.2.0",
     "ts-node": "^10.9.1",
-    "typescript": "~4.9.5",
+    "typescript": "~5.1.0",
     "yargs": "^17.1.1"
   },
   "devDependencies": {

--- a/test/programs/const-keyword/main.ts
+++ b/test/programs/const-keyword/main.ts
@@ -1,0 +1,4 @@
+const fn = <const T>(value: T) =>
+  ({ value });
+
+export type Object = ReturnType<typeof fn<"value">>;

--- a/test/programs/const-keyword/schema.json
+++ b/test/programs/const-keyword/schema.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "properties": {
+        "value": {
+            "const": "value",
+            "type": "string"
+        }
+    },
+    "required": ["value"],
+    "type": "object"
+}
+

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -523,3 +523,7 @@ describe("when reusing a generator", () => {
 describe("satisfies keyword - ignore from a \"satisfies\" and build by rally type", () => {
     assertSchema("satisfies-keyword", "Specific");
 });
+
+describe("const keyword", () => {
+    assertSchema("const-keyword", "Object");
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,8 +19,8 @@
         "noLib": false,
         "preserveConstEnums": true,
         "sourceMap": true,
-        "watch": false,
-        "typeRoots" : ["node_modules/@types"]
+        "typeRoots" : ["node_modules/@types"],
+        "ignoreDeprecations": "5.0"
     },
     "include": [
         "**/*.ts",

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1052,8 +1052,8 @@ export class JsonSchemaGenerator {
             return !(
                 decls &&
                 decls.filter((decl) => {
-                    const mods = decl.modifiers;
-                    return mods && mods.filter((mod) => mod.kind === ts.SyntaxKind.PrivateKeyword).length > 0;
+                    const mods = (decl as any).modifiers;
+                    return mods && mods.filter((mod: any) => mod.kind === ts.SyntaxKind.PrivateKeyword).length > 0;
                 }).length > 0
             );
         });
@@ -1154,7 +1154,7 @@ export class JsonSchemaGenerator {
                 const requiredProps = props.reduce((required: string[], prop: ts.Symbol) => {
                     const def = {};
                     this.parseCommentsIntoDefinition(prop, def, {});
-                    const allUnionTypesFlags: number[] = (<any>prop).type?.types?.map?.((t: any) => t.flags) || [];
+                    const allUnionTypesFlags: number[] = (<any>prop).links?.type?.types?.map?.((t: any) => t.flags) || [];
                     if (
                         !(prop.flags & ts.SymbolFlags.Optional) &&
                         !(prop.flags & ts.SymbolFlags.Method) &&
@@ -1373,7 +1373,7 @@ export class JsonSchemaGenerator {
 
             if (definition.type === undefined) {
                 // if users override the type, do not try to infer it
-                if (typ.flags & ts.TypeFlags.Union) {
+                if (typ.flags & ts.TypeFlags.Union && (node === null || node.kind !== ts.SyntaxKind.EnumDeclaration)) {
                     this.getUnionDefinition(typ as ts.UnionType, unionModifier, definition);
                 } else if (typ.flags & ts.TypeFlags.Intersection) {
                     if (this.args.noExtraProps) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -894,10 +894,10 @@ type-detect@^4.0.0, type-detect@^4.0.5:
   resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
 
-typescript@~4.9.5:
-  version "4.9.5"
-  resolved "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz"
-  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+typescript@~5.1.0:
+  version "5.1.6"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.1.6.tgz#02f8ac202b6dad2c0dd5e0913745b47a37998274"
+  integrity sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==
 
 uri-js@^4.2.2:
   version "4.4.1"


### PR DESCRIPTION
This is probably the minimal commit to make the Typescript 5 work. But

- there are deprecations warnings regarding the tsconfig
- there are type problems in the `typescript-json-schema.ts`, some parts use fields not exposed by typescript, this will inevitably lead to problems in future if these internals change

These should be addressed in the future.

On top of included tests I tested these changes on my company's internal codebase. Seems to work fine.