### PR TITLE
fix: avoid unrelated schemaOverrides when building definition for single type

### DIFF
--- a/test/programs/no-unrelated-definitions/schema.MyOtherObjectWithOverride.json
+++ b/test/programs/no-unrelated-definitions/schema.MyOtherObjectWithOverride.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "SomeOtherDefinition": {
+      "type": "string"
+    }
+  },
+  "properties": {
+      "sub": {
+          "$ref": "#/definitions/SomeOtherDefinition"
+      }
+  },
+  "type": "object"
+}

--- a/test/programs/no-unrelated-definitions/schema.program.json
+++ b/test/programs/no-unrelated-definitions/schema.program.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "definitions": {
+    "MyObject": {
+      "properties": {
+        "sub": {
+          "$ref": "#/definitions/SomeDefinition"
+        }
+      },
+      "type": "object"
+    },
+    "MyOtherObject": {
+      "properties": {
+        "sub": {
+          "$ref": "#/definitions/SomeOtherDefinition"
+        }
+      },
+      "type": "object"
+    },
+    "SomeDefinition": {
+      "properties": {
+        "is": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "SomeOtherDefinition": {
+      "properties": {
+        "is": {
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
+    "UnrelatedDefinition": {
+      "type": "string"
+    }
+  }
+}


### PR DESCRIPTION
Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`


I want to use `setSchemaOverride` to override some types and then generate separate schema files per type with `getSchemaForSymbol`. Current implementation adds all overrides to each schema even if they are not used. This PR removes that behavior by default and adds an option `includeAllOverrides` to return it.
The `includeAllOverrides` is also enabled by default when generating schema for whole program.