### PR TITLE
fix: return overrides schema in getSchemaForSymbol

### DIFF
--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -168,6 +168,52 @@ describe("interfaces", () => {
             assert.deepEqual(schema.definitions!["MySubObject"], schemaOverride);
         }
     });
+    it("should output the schemas set by setSchemaOverride with getSchemaForSymbol", () => {
+        const program = TJS.getProgramFromFiles([resolve(BASE + "interface-multi/main.ts")]);
+        const generator = TJS.buildGenerator(program);
+        assert(generator !== null);
+
+        const schemaOverride1: TJS.Definition = { type: "string" };
+        const schemaOverride2: TJS.Definition = { type: "integer" };
+
+        generator?.setSchemaOverride("MySubObject", schemaOverride1);
+        generator?.setSchemaOverride("MySubObject2", schemaOverride2);
+        const schema = generator?.getSchemaForSymbol("MySubObject");
+
+        // Should not change original schema object.
+        assert.deepEqual(schemaOverride1,  { type: "string" });
+        assert.deepEqual(schemaOverride2,  { type: "integer" });
+
+        assert.deepEqual(schema, { ...schemaOverride1, $schema: "http://json-schema.org/draft-07/schema#" });
+    });
+    it("should output the schemas set by setSchemaOverride with getSchemaForSymbol and other overrides", () => {
+        const program = TJS.getProgramFromFiles([resolve(BASE + "interface-multi/main.ts")]);
+        const generator = TJS.buildGenerator(program);
+        assert(generator !== null);
+        const schemaOverride1: TJS.Definition = { type: "string" };
+        const schemaOverride2: TJS.Definition = { type: "integer" };
+
+        generator?.setSchemaOverride("MySubObject1", schemaOverride1);
+        generator?.setSchemaOverride("MySubObject2", schemaOverride2);
+        const schema = generator?.getSchemaForSymbol("MySubObject1", true, true);
+
+        // Should not change original schema object.
+        assert.deepEqual(schemaOverride1,  { type: "string" });
+        assert.deepEqual(schemaOverride2,  { type: "integer" });
+
+        assert.deepEqual(schema, {
+            ...schemaOverride1,
+            $schema: "http://json-schema.org/draft-07/schema#",
+            definitions: {
+                MySubObject1: {
+                    type: "string"
+                },
+                MySubObject2: {
+                    type: "integer"
+                }
+            }
+        });
+    });
     it("should ignore type aliases that have schema overrides", () => {
         const program = TJS.getProgramFromFiles([resolve(BASE + "type-alias-schema-override/main.ts")]);
         const generator = TJS.buildGenerator(program);

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1518,20 +1518,26 @@ export class JsonSchemaGenerator {
     }
 
     public getSchemaForSymbol(symbolName: string, includeReffedDefinitions: boolean = true, includeAllOverrides: boolean = false): Definition {
-        if (!this.allSymbols[symbolName]) {
+        const overrideDefinition = this.schemaOverrides.get(symbolName);
+        if (!this.allSymbols[symbolName] && !overrideDefinition) {
             throw new Error(`type ${symbolName} not found`);
         }
 
         this.resetSchemaSpecificProperties(includeAllOverrides);
 
-        const def = this.getTypeDefinition(
-            this.allSymbols[symbolName],
-            this.args.topRef,
-            undefined,
-            undefined,
-            undefined,
-            this.userSymbols[symbolName] || undefined
-        );
+        let def;
+        if (overrideDefinition) {
+            def = { ...overrideDefinition };
+        } else {
+            def = overrideDefinition ? overrideDefinition : this.getTypeDefinition(
+              this.allSymbols[symbolName],
+              this.args.topRef,
+              undefined,
+              undefined,
+              undefined,
+              this.userSymbols[symbolName] || undefined
+            );
+        }
 
         if (this.args.ref && includeReffedDefinitions && Object.keys(this.reffedDefinitions).length > 0) {
             def.definitions = this.reffedDefinitions;


### PR DESCRIPTION
Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`

Depends on https://github.com/YousefED/typescript-json-schema/pull/589.

The `getSchemaForSymbol` method doesn't return schemas overridden with `setSchemaOverride` and instead falls back to generating the type for that schema. This PR changes the behavior to always prioritize `setSchemaOverride`.