### PR TITLE
Remove suppressImplicitAnyIndexErrors from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,6 @@
         "emitDecoratorMetadata": true,
         "declaration": true,
         "noImplicitAny": true,
-        "suppressImplicitAnyIndexErrors": true,
         "strictNullChecks": true,
         "noImplicitReturns": true,
         "noFallthroughCasesInSwitch": true,
@@ -20,7 +19,6 @@
         "preserveConstEnums": true,
         "sourceMap": true,
         "typeRoots" : ["node_modules/@types"],
-        "ignoreDeprecations": "5.0"
     },
     "include": [
         "**/*.ts",


### PR DESCRIPTION
Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [ ] Provide a test case & update the documentation in the `Readme.md`

This PR is a continuation of the Typescript v5 upgrade (#564) that factors out the implicit use of index signatures, allowing `suppressImplicitAnyIndexErrors` and `ignoreDeprecations` to be removed from the tsconfig.

Due to the extensive use of indexing into interfaces (namely `Definition`), I have created a `DefinitionIndex` type that is a looser version of `Definition` allowing indexing. In other cases I needed to cast a type as a `Record` or cast a key `as keyof Definition` in order to allow the desired indexing.

Let me know if you know of a more elegant approach, or have any additional feedback.