### PR TITLE
fix: correctly identify imports with resolution-mode (#582)

### DIFF
--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -9,7 +9,7 @@ export { Program, CompilerOptions, Symbol } from "typescript";
 
 const vm = require("vm");
 
-const REGEX_FILE_NAME_OR_SPACE = /(\bimport\(".*?"\)|".*?")\.| /g;
+const REGEX_FILE_NAME_OR_SPACE = /(\bimport\(".*?"(, \{ assert: \{ "resolution-mode": "(import|require)" \} \})?\)|".*?")\.| /g;
 const REGEX_TSCONFIG_NAME = /^.*\.json$/;
 const REGEX_TJS_JSDOC = /^-([\w]+)\s+(\S|\S[\s\S]*\S)\s*$/g;
 const REGEX_GROUP_JSDOC = /^[.]?([\w]+)\s+(\S|\S[\s\S]*\S)\s*$/g;


### PR DESCRIPTION
Used fix provided by @jer-sen and closes #582 

 I _believe_ this only occurs for ESM projects with `"moduleResolution": "NodeNext"` in `tsconfig.json` and introduced in [TS 4.7](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7-beta/#resolution-mode). This fix is backwards compatible.