### PR TITLE
Fix/pattern escape

### DIFF
--- a/test/programs/string-template-literal/main.ts
+++ b/test/programs/string-template-literal/main.ts
@@ -8,4 +8,7 @@ interface MyObject {
   g: `${string}@`,
   h: `${number}@`,
   i: `${string}@${number}`,
+  j: `{{${string}}}`
+  k: `${string}\n`
+  l: `${string}-${string}`
 }

--- a/test/programs/string-template-literal/schema.json
+++ b/test/programs/string-template-literal/schema.json
@@ -39,6 +39,18 @@
       "i": {
         "type": "string",
         "pattern": "^.*@[0-9]*$"
+      },
+      "j": {
+        "pattern": "^\\{\\{.*\\}\\}$",
+        "type": "string"
+      },
+      "k": {
+        "pattern": "^.*\\n$",
+        "type": "string"
+      },
+      "l": {
+        "pattern": "^.*-.*$",
+        "type": "string"
       }
     },
     "additionalProperties": false,
@@ -51,7 +63,10 @@
       "f",
       "g",
       "h",
-      "i"
+      "i",
+      "j",
+      "k",
+      "l"
     ],
     "$schema": "http://json-schema.org/draft-07/schema#"
 }


### PR DESCRIPTION
This PR fixes control character handling when emitting regex patterns. The list of control characters are obtained from <https://json-schema.org/understanding-json-schema/reference/regular_expressions>.

Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`
