### PR TITLE
feat: include tuple names in json schema

### DIFF
--- a/test/programs/type-aliases-tuple-with-names/main.ts
+++ b/test/programs/type-aliases-tuple-with-names/main.ts
@@ -1,0 +1,1 @@
+export type MyTuple = [a: string, b: 123, c?: boolean, ...d: number[]];

--- a/test/programs/type-aliases-tuple-with-names/schema.json
+++ b/test/programs/type-aliases-tuple-with-names/schema.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "array",
+  "items": [
+    {
+      "title": "a",
+      "type": "string"
+    },
+    {
+      "title": "b",
+      "type": "number",
+      "const": 123
+    },
+    {
+      "title": "c",
+      "type": "boolean"
+    }
+  ],
+  "minItems": 2,
+  "additionalItems": {
+    "title": "d",
+    "type": "number"
+  }
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -297,6 +297,7 @@ describe("schema", () => {
         assertSchema("type-aliases-recursive-anonymous", "MyAlias");
         assertSchema("type-aliases-recursive-export", "MyObject");
         */
+        assertSchema("type-aliases-tuple-with-names", "MyTuple");
         assertSchema("type-aliases-tuple-of-variable-length", "MyTuple");
         assertSchema("type-aliases-tuple-with-rest-element", "MyTuple");
         assertRejection("type-alias-never", "MyNever", {}, {}, /Unsupported type: never/);

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -657,12 +657,20 @@ export class JsonSchemaGenerator {
         if (tupleType) {
             // tuple
             const elemTypes: ts.NodeArray<ts.TypeNode> = (propertyType as any).typeArguments;
-            const fixedTypes = elemTypes.map((elType) => this.getTypeDefinition(elType as any));
+            const targetTupleType = (propertyType as ts.TupleTypeReference).target;
+
+            const fixedTypes = elemTypes.map((elType, index) => {
+                const def = this.getTypeDefinition(elType as any);
+                const label = targetTupleType.labeledElementDeclarations?.[index]?.name?.getFullText().trim();
+                if (label) {
+                    def.title = label;
+                }
+                return def;
+            });
             definition.type = "array";
             if (fixedTypes.length > 0) {
                 definition.items = fixedTypes;
             }
-            const targetTupleType = (propertyType as ts.TupleTypeReference).target;
             definition.minItems = targetTupleType.minLength;
             if (targetTupleType.hasRestElement) {
                 definition.additionalItems = fixedTypes[fixedTypes.length - 1];


### PR DESCRIPTION
Since TypeScript v4.0, tuples can have names (or 'labels'). For example: 

```ts
type T = [start: number, end: number];
```

This PR includes these names in the JSON schema

---

Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`
