### PR TITLE
feat: expose internal ts object

### DIFF
--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -3,8 +3,9 @@ import addFormats from "ajv-formats";
 import { assert } from "chai";
 import { readFileSync } from "fs";
 import { resolve } from "path";
-import { versionMajorMinor as typescriptVersionMajorMinor } from "typescript";
 import * as TJS from "../typescript-json-schema";
+
+const { versionMajorMinor: typescriptVersionMajorMinor } = TJS.ts;
 
 let ajvWarnings: string[] = [];
 const ajv = new Ajv({

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -7,6 +7,8 @@ import { JSONSchema7, JSONSchema7TypeName } from "json-schema";
 import { pathEqual } from "path-equal";
 export { Program, CompilerOptions, Symbol } from "typescript";
 
+export { ts };
+
 const vm = require("vm");
 
 const REGEX_FILE_NAME_OR_SPACE = /(\bimport\(".*?"\)|".*?")\.| /g;


### PR DESCRIPTION
Expose the internal `ts` object to allow custom program creation.

My use case is to create a compiler host that can inject virtual files:

```ts
const configPath = path.resolve('./tsconfig.json');
const dir = path.dirname(configPath);
const { config } = ts.readConfigFile(configPath, ts.sys.readFile);
const { options } = ts.parseJsonConfigFileContent(config, ts.sys, dir);

const customHost = ts.createCompilerHost(options);
const getSourceFile = customHost.getSourceFile;

customHost.getSourceFile = (file, version, onError, create) => {
  if (file === vFile) return ts.createSourceFile(file, vContents, version);
  return getSourceFile.call(customHost, file, version, onError, create);
};

const program = ts.createProgram([vFile], options, customHost);
const bad = TJS.generateSchema(program, ...);
```

The issue is that if my project is using a newer version of TypeScript, the types won't match up and this will be runtime error. The hacky workaround is to import `ts` as

```ts
import ts from 'typescript-json-schema/node_modules/typescript';
```

Which is not ideal and will break on different package managers. Exposing the internal `ts` object allows easy access to create customizations without having to rely on hacks.

Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`
