### PR TITLE
chore: bump vm2 to 3.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "safe-stable-stringify": "^2.5.0",
     "ts-node": "^10.9.2",
     "typescript": "~5.9.3",
-    "vm2": "^3.10.5",
+    "vm2": "^3.11.3",
     "yargs": "^18.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1006,10 +1006,10 @@ v8-compile-cache-lib@^3.0.1:
   resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
-vm2@^3.10.5:
-  version "3.11.2"
-  resolved "https://registry.npmjs.org/vm2/-/vm2-3.11.2.tgz#68ea22497c2c37cb907f27106a3c952dd9e318a6"
-  integrity sha512-hnsYAgBSAgwwPM/Gq66gMmUY0VlY9mKC8nvVRAZiJp+tYxF4sfNRlZymP8uqzIUK2U/7+SVZ/H8p7USxNHLlZA==
+vm2@^3.11.3:
+  version "3.11.3"
+  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.11.3.tgz#5323018a93ae2862c9d52b07b658ebb8d74903f0"
+  integrity sha512-DO1TTKuOc+veL11VNOvJwRab80mghFKE40Av3bl6pdXs11bdiDMuR73owy+dS2EsTZEvRUeBkkBuDVRjV/RgEw==
   dependencies:
     acorn "^8.15.0"
     acorn-walk "^8.3.4"


### PR DESCRIPTION
### Summary
Updates the vm2 dependency from ^3.10.5 to ^3.11.3.
Locks updated in yarn.lock to reflect the new resolved version.

### Motivation
Keeps vm2 up to date to pick up any bug fixes and improvements shipped in patch/minor releases between 3.10.5 and 3.11.3. This closes a critical vulnerability in vm2 and is referenced in #631.

All tests execute successfully.