### PR TITLE
fix: evaluate property default initializers via AST instead of vm2

### DIFF
--- a/api.md
+++ b/api.md
@@ -691,6 +691,23 @@ class MyObject {
 ```
 
 
+## [default-properties-initializer](./test/programs/default-properties-initializer)
+
+```ts
+export class MyObject {
+    varString: string = "foo";
+    varSingleQuoted: string = 'bar';
+    varNumber: number = 123;
+    varFloat: number = 3.21;
+    varNegative: number = -5;
+    varBoolean: boolean = true;
+    varNull: null = null;
+    varArray: number[] = [1, 2, 3];
+    varStringArray: string[] = ["a", "b"];
+}
+```
+
+
 ## [enums-compiled-compute](./test/programs/enums-compiled-compute)
 
 ```ts

--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "safe-stable-stringify": "^2.5.0",
     "ts-node": "^10.9.2",
     "typescript": "~5.9.3",
-    "vm2": "^3.11.3",
     "yargs": "^18.0.0"
   },
   "devDependencies": {

--- a/test/programs/default-properties-initializer/main.ts
+++ b/test/programs/default-properties-initializer/main.ts
@@ -1,0 +1,11 @@
+export class MyObject {
+    varString: string = "foo";
+    varSingleQuoted: string = 'bar';
+    varNumber: number = 123;
+    varFloat: number = 3.21;
+    varNegative: number = -5;
+    varBoolean: boolean = true;
+    varNull: null = null;
+    varArray: number[] = [1, 2, 3];
+    varStringArray: string[] = ["a", "b"];
+}

--- a/test/programs/default-properties-initializer/schema.json
+++ b/test/programs/default-properties-initializer/schema.json
@@ -1,0 +1,67 @@
+{
+    "type": "object",
+    "properties": {
+        "varString": {
+            "type": "string",
+            "default": "foo"
+        },
+        "varSingleQuoted": {
+            "type": "string",
+            "default": "bar"
+        },
+        "varNumber": {
+            "type": "number",
+            "default": 123
+        },
+        "varFloat": {
+            "type": "number",
+            "default": 3.21
+        },
+        "varNegative": {
+            "type": "number",
+            "default": -5
+        },
+        "varBoolean": {
+            "type": "boolean",
+            "default": true
+        },
+        "varNull": {
+            "type": "null",
+            "default": null
+        },
+        "varArray": {
+            "type": "array",
+            "items": {
+                "type": "number"
+            },
+            "default": [
+                1,
+                2,
+                3
+            ]
+        },
+        "varStringArray": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "default": [
+                "a",
+                "b"
+            ]
+        }
+    },
+    "additionalProperties": false,
+    "required": [
+        "varArray",
+        "varBoolean",
+        "varFloat",
+        "varNegative",
+        "varNull",
+        "varNumber",
+        "varSingleQuoted",
+        "varString",
+        "varStringArray"
+    ],
+    "$schema": "http://json-schema.org/draft-07/schema#"
+}

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -423,6 +423,8 @@ describe("schema", () => {
 
         assertSchema("default-properties", "MyObject");
 
+        assertSchema("default-properties-initializer", "MyObject");
+
         // not supported yet #116
         // assertSchema("interface-extra-props", "MyObject");
 

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -9,8 +9,6 @@ export { Program, CompilerOptions, Symbol } from "typescript";
 
 export { ts };
 
-const { VM } = require("vm2");
-
 const REGEX_FILE_NAME_OR_SPACE = /(\bimport\(".*?"\)|".*?")\.| /g;
 const REGEX_TSCONFIG_NAME = /^.*\.json$/;
 const REGEX_TJS_JSDOC = /^-([\w]+)\s+(\S|\S[\s\S]*\S)\s*$/g;
@@ -248,6 +246,40 @@ function parseValue(symbol: ts.Symbol, key: string, value: string): any {
     } catch (error) {
         return value;
     }
+}
+
+/**
+ * Evaluate a property initializer expression to its literal value, without
+ * executing any code. Only the literal forms that can be represented in a JSON
+ * Schema `default` are supported: string, number, boolean, null and arrays of
+ * those. Returns `undefined` for anything that is not a supported literal.
+ */
+function evaluateLiteralInitializer(node: ts.Node): PrimitiveType | any[] | undefined {
+    if (ts.isStringLiteralLike(node)) {
+        return node.text;
+    } else if (ts.isNumericLiteral(node)) {
+        return Number(node.text);
+    } else if (ts.isPrefixUnaryExpression(node) && node.operator === ts.SyntaxKind.MinusToken) {
+        const operand = evaluateLiteralInitializer(node.operand);
+        return typeof operand === "number" ? -operand : undefined;
+    } else if (node.kind === ts.SyntaxKind.TrueKeyword) {
+        return true;
+    } else if (node.kind === ts.SyntaxKind.FalseKeyword) {
+        return false;
+    } else if (node.kind === ts.SyntaxKind.NullKeyword) {
+        return null;
+    } else if (ts.isArrayLiteralExpression(node)) {
+        const values: any[] = [];
+        for (const element of node.elements) {
+            const value = evaluateLiteralInitializer(element);
+            if (value === undefined) {
+                return undefined;
+            }
+            values.push(value);
+        }
+        return values;
+    }
+    return undefined;
 }
 
 function extractLiteralValue(typ: ts.Type): PrimitiveType | undefined {
@@ -866,22 +898,11 @@ export class JsonSchemaGenerator {
             } else if ((<any>initial).kind && (<any>initial).kind === ts.SyntaxKind.NoSubstitutionTemplateLiteral) {
                 definition.default = initial.getText();
             } else {
-                try {
-                    const vm = new VM();
-                    const val = vm.run("sandboxvar=" + initial.getText()) as any;
-                    if (
-                        val === null ||
-                        typeof val === "string" ||
-                        typeof val === "number" ||
-                        typeof val === "boolean" ||
-                        Object.prototype.toString.call(val) === "[object Array]"
-                    ) {
-                        definition.default = val;
-                    } else if (val) {
-                        console.warn("unknown initializer for property " + propertyName + ": " + val);
-                    }
-                } catch (e) {
-                    console.warn("exception evaluating initializer for property " + propertyName);
+                const val = evaluateLiteralInitializer(initial);
+                if (val !== undefined) {
+                    definition.default = val;
+                } else {
+                    console.warn("unknown initializer for property " + propertyName + ": " + initial.getText());
                 }
             }
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -108,14 +108,14 @@
   dependencies:
     undici-types "~7.16.0"
 
-acorn-walk@^8.1.1, acorn-walk@^8.3.4:
+acorn-walk@^8.1.1:
   version "8.3.5"
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz#8a6b8ca8fc5b34685af15dabb44118663c296496"
   integrity sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==
   dependencies:
     acorn "^8.11.0"
 
-acorn@^8.11.0, acorn@^8.15.0, acorn@^8.4.1:
+acorn@^8.11.0, acorn@^8.4.1:
   version "8.16.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz#4ce79c89be40afe7afe8f3adb902a1f1ce9ac08a"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -1005,14 +1005,6 @@ v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
-
-vm2@^3.11.3:
-  version "3.11.3"
-  resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.11.3.tgz#5323018a93ae2862c9d52b07b658ebb8d74903f0"
-  integrity sha512-DO1TTKuOc+veL11VNOvJwRab80mghFKE40Av3bl6pdXs11bdiDMuR73owy+dS2EsTZEvRUeBkkBuDVRjV/RgEw==
-  dependencies:
-    acorn "^8.15.0"
-    acorn-walk "^8.3.4"
 
 which@^2.0.1:
   version "2.0.2"


### PR DESCRIPTION
Please:
- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`

---

This drops the `vm2` dependency entirely.

### Why

Every scanner I point at a project that pulls this package in lights up because of `vm2` — Dependabot, `npm audit`, our internal SCA, all of them. `vm2` is [archived/unmaintained](https://github.com/patriksimek/vm2) and the sandbox-escape advisory in #631 (GHSA-99p7-6v5w-7xg8) has no fix coming, because the maintainers concluded it's not really fixable. #635 bumped the version to quiet it down, but a version bump can't fix something that has no patched release, so it keeps coming back.

Digging into why `vm2` is even here: it's only used in one spot — evaluating a property's initializer to figure out the `default` value:

```ts
class Foo {
  bar: string = "baz";  // <- we want "baz" in the schema default
}
```

The history is kind of a loop, actually. #628 flagged that running the tool on a malicious `.ts` file could execute code (because it evals the initializer text), so #629 swapped `vm` → `vm2` to sandbox it harder... and then #631 pointed out `vm2` itself is the vulnerable thing now. So we went from "eval is scary" to "the thing we used to make eval less scary is scary." 🙃

### The fix / why this way

Instead of *executing* the initializer in any sandbox, just read the literal value straight off the TypeScript AST (`ts.isStringLiteralLike`, `ts.isNumericLiteral`, `ts.isArrayLiteralExpression`, etc). We already have the parsed node — there's no real reason to run it through a VM to find out that `[1, 2, 3]` is `[1, 2, 3]`.

Nice side effect: this closes #628 too. Since nothing is ever executed, a malicious initializer like `bar = (() => { /* do evil */ })()` just isn't a supported literal node, so it returns `undefined` and hits the existing `"unknown initializer"` warning path — same as before, minus the arbitrary code execution.

I deliberately kept it to the raw AST layer and did **not** reach for the `TypeChecker`. The TypeChecker would happily resolve `bar = SOME_CONST` to its value by following references across files — which sounds nice but is exactly the "reach beyond what's literally written here" behavior that made this risky in the first place, and it also can't give you array literals as values (they widen to `{}`). `vm2` didn't resolve those references either, so staying at the AST layer keeps behavior identical for valid defaults.

Supported literal forms: string, number (including negatives), boolean, `null`, and arrays of those — which matches what the old `vm2` block accepted.

### Testing

Added a `default-properties-initializer` fixture covering the above, including a single-quoted string and a negative number (a couple of cases a naive `JSON.parse` swap would've choked on, which is partly why I went the AST route). All existing tests still pass — `default-properties` / `annotation-default` are unchanged, so behaviour for real defaults is the same.

`api.md` picked up the new fixture automatically via `yarn docs`.

Happy to adjust naming or split things out if you'd prefer — first PR here so lmk if I got the conventions wrong.

Closes #631
Closes #628