### PR TITLE
fix: respect constAsEnum in all const-emitting code paths(#588)

### DIFF
--- a/api.md
+++ b/api.md
@@ -625,8 +625,29 @@ export interface MyObject {
 ## [const-as-enum](./test/programs/const-as-enum)
 
 ```ts
+export enum Enum {
+    X = 0,
+    Y = 1,
+}
+
 export interface MyObject {
     reference: true;
+    member: Enum.X;
+}
+```
+
+
+## [const-as-enum-strict](./test/programs/const-as-enum-strict)
+
+```ts
+export type X = Y | Z;
+
+export interface Y {
+    myProp?: false;
+}
+
+export interface Z {
+    myProp: true;
 }
 ```
 

--- a/test/programs/const-as-enum-strict/main.ts
+++ b/test/programs/const-as-enum-strict/main.ts
@@ -1,0 +1,9 @@
+export type X = Y | Z;
+
+export interface Y {
+    myProp?: false;
+}
+
+export interface Z {
+    myProp: true;
+}

--- a/test/programs/const-as-enum-strict/schema.json
+++ b/test/programs/const-as-enum-strict/schema.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "anyOf": [
+        {
+            "$ref": "#/definitions/Y"
+        },
+        {
+            "$ref": "#/definitions/Z"
+        }
+    ],
+    "definitions": {
+        "Y": {
+            "additionalProperties": false,
+            "properties": {
+                "myProp": {
+                    "enum": [
+                        false
+                    ],
+                    "type": "boolean"
+                }
+            },
+            "type": "object"
+        },
+        "Z": {
+            "additionalProperties": false,
+            "properties": {
+                "myProp": {
+                    "enum": [
+                        true
+                    ],
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "myProp"
+            ],
+            "type": "object"
+        }
+    }
+}

--- a/test/programs/const-as-enum/main.ts
+++ b/test/programs/const-as-enum/main.ts
@@ -1,3 +1,9 @@
+export enum Enum {
+    X = 0,
+    Y = 1,
+}
+
 export interface MyObject {
     reference: true;
+    member: Enum.X;
 }

--- a/test/programs/const-as-enum/schema.json
+++ b/test/programs/const-as-enum/schema.json
@@ -1,15 +1,27 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "additionalProperties": false,
+    "definitions": {
+        "Enum.X": {
+            "enum": [
+                0
+            ],
+            "type": "number"
+        }
+    },
     "properties": {
+        "member": {
+            "$ref": "#/definitions/Enum.X"
+        },
         "reference": {
             "enum": [
-              true
+                true
             ],
             "type": "boolean"
         }
     },
     "required": [
+        "member",
         "reference"
     ],
     "type": "object"

--- a/test/schema.test.ts
+++ b/test/schema.test.ts
@@ -642,4 +642,7 @@ describe("const keyword", () => {
 
 describe("constAsEnum option", () => {
     assertSchema("const-as-enum", "MyObject", { constAsEnum: true });
+    assertSchema("const-as-enum-strict", "X", { constAsEnum: true, strictNullChecks: true }, {
+        strictNullChecks: true,
+    });
 });

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -679,6 +679,15 @@ export class JsonSchemaGenerator {
         });
     }
 
+    private setSingleValue(definition: Definition, value: PrimitiveType): Definition {
+        if (this.constAsEnum) {
+            definition.enum = [value];
+        } else {
+            definition.const = value;
+        }
+        return definition;
+    }
+
     private getDefinitionForRootType(
         propertyType: ts.Type,
         reffedType: ts.Symbol,
@@ -773,11 +782,7 @@ export class JsonSchemaGenerator {
                         default:
                             throw new Error(`Not supported: ${value} as a enum value`);
                     }
-                    if (this.constAsEnum) {
-                        definition.enum = [value];
-                    } else {
-                        definition.const = value;
-                    }
+                    this.setSingleValue(definition, value);
                 } else if (arrayType !== undefined) {
                     if (
                         propertyType.flags & ts.TypeFlags.Object &&
@@ -970,7 +975,7 @@ export class JsonSchemaGenerator {
             if (enumValues.length > 1) {
                 definition.enum = enumValues;
             } else {
-                definition.const = enumValues[0];
+                this.setSingleValue(definition, enumValues[0]);
             }
         }
 
@@ -1032,7 +1037,8 @@ export class JsonSchemaGenerator {
             if (isOnlyBooleans) {
                 pushSimpleType("boolean");
             } else {
-                const enumSchema: Definition = enumValues.length > 1 ? { enum: enumValues.sort() } : { const: enumValues[0] };
+                const enumSchema: Definition =
+                    enumValues.length > 1 ? { enum: enumValues.sort() } : this.setSingleValue({}, enumValues[0]);
 
                 // If all values are of the same primitive type, add a "type" field to the schema
                 if (


### PR DESCRIPTION
Fixes #588

## Problem

`constAsEnum` is only respected in one of the three places that emit a single fixed value:

| location | path | respects |
|---|---|---|
| `typescript-json-schema.ts:776` | literal type | yes |
| `typescript-json-schema.ts:973` | enum member type | **no** |
| `typescript-json-schema.ts:1035` | union collapsing to one value | **no** |

So `const` still leaks out with the flag on, and the document is not valid OpenAPI 3.0:

```ts
interface MyObject {
    reference: true;   // { "enum": [true] }  ok
    member: Enum.X;    // { "const": 0 }      expected { "enum": [0] }
}
```

## What changed

The const-vs-enum decision moves into one `setSingleValue` helper used by all three sites, so they cannot drift apart again. It returns the definition, which keeps the union site's original ternary.

Two test cases added — an enum member type, and the reproduction from #588. Both fail on branch `master`.

## Impact

None when `constAsEnum` is off, which is the default. The existing `enums-value-in-interface` test covers the same enum member shape with the flag off, still expects `const`, and passes unchanged.

---

- [x] Make your pull request atomic, fixing one issue at a time unless there are many relevant issues that cannot be decoupled.
- [x] Provide a test case & update the documentation in the `Readme.md`
  `Readme.md` is unchanged: `--constAsEnum` is already documented there and this makes the implementation match it. 