### PR TITLE
fix: compare included files with path semantics

### DIFF
--- a/test/windows-path-matching.test.ts
+++ b/test/windows-path-matching.test.ts
@@ -1,0 +1,16 @@
+import { assert } from "chai";
+import { resolve } from "path";
+import * as TJS from "../typescript-json-schema";
+
+describe("user file path matching", () => {
+    it("should treat equivalent slash styles as the same user file", () => {
+        const file = resolve("test/programs/comments/main.ts");
+        const alternateFile = file.includes("\\") ? file.replace(/\\/g, "/") : file.replace(/\//g, "\\");
+        const program = TJS.getProgramFromFiles([file]);
+        const generator = TJS.buildGenerator(program, {}, [alternateFile]);
+
+        assert.instanceOf(generator, TJS.JsonSchemaGenerator);
+        assert.include(generator!.getUserSymbols(), "MyObject");
+        assert.include(generator!.getMainFileSymbols(program, [alternateFile]), "MyObject");
+    });
+});

--- a/typescript-json-schema.ts
+++ b/typescript-json-schema.ts
@@ -1713,7 +1713,7 @@ export function buildGenerator(
         if (onlyIncludeFiles === undefined) {
             return !file.hasNoDefaultLib;
         }
-        return onlyIncludeFiles.indexOf(file.fileName) >= 0;
+        return onlyIncludeFiles.some((f) => pathEqual(f, file.fileName));
     }
     // Use defaults unless otherwise specified
     const settings = getDefaultArgs();


### PR DESCRIPTION
Fixes #638.

## Problem

On Windows, wildcard (`"*"`) schema generation can silently return an empty `definitions` object when `glob` and TypeScript represent the same source path with different separators.

Observed for the same file:

    glob:       schema\draft\schema.ts
    TypeScript: schema/draft/schema.ts

    exact string equality: false
    pathEqual:             true

`buildGenerator()` currently uses exact string membership, which can leave `userSymbols` empty even though named symbols remain available.

## Fix

Use the existing `pathEqual()` helper:

    - return onlyIncludeFiles.indexOf(file.fileName) >= 0;
    + return onlyIncludeFiles.some((f) => pathEqual(f, file.fileName));

The library already uses `pathEqual()` for a related comparison in `getMainFileSymbols()`.

## Regression test

Adds a focused test using opposite slash styles for the same source file and verifies that it is still classified as a user/main-file source.

No workflow or schema-tooling changes.

## Windows validation

Validated while investigating modelcontextprotocol/modelcontextprotocol#3114 with typescript-json-schema 0.68.0.

Fresh Windows generation after this one-line fix produced:

    2024-11-05     79 definitions
    2025-03-26     83 definitions
    2025-06-18     91 definitions
    2025-11-25    145 definitions
    2026-07-28    155 definitions
    draft         155 definitions

The regenerated schema files had no diff from the checked-in schemas.

Example validation:

    Results: 258 passed, 0 failed